### PR TITLE
Correction of #5

### DIFF
--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -27,7 +27,7 @@ class LinFrame:
 		self._packer = bitstruct.compile(self._pattern)
 
 	def _frame_pattern(self, frame_bits: int, signals: List[Tuple[int, LinSignal]]) -> str:
-		pattern = ""
+		pattern = "<"
 		offset = 0
 		for signal in signals:
 			if signal[0] < offset:

--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -55,7 +55,7 @@ class LinFrame:
 				message.append(data.get(signal.name))
 			else:
 				message.append(signal.init_value[0])
-		return self._packer.pack(*message)
+		return self._flip_bytearray(self._packer.pack(*message))
 
 	def data(self, data: Dict[str, Union[str, int, float]], converters: Dict[str, LinSignalType]) -> bytearray:
 		"""
@@ -73,7 +73,7 @@ class LinFrame:
 		Returns a mapping between Signal names and their raw physical values in the given message
 		"""
 		message = {}
-		unpacked = self._packer.unpack(data)
+		unpacked = self._packer.unpack(self._flip_bytearray(data))
 		for i in range(len(unpacked)):
 			message[self.signals[i].name] = unpacked[i]
 		return message
@@ -101,4 +101,10 @@ class LinFrame:
 
 	def __str__(self):
 		return "Frame(id=" + str(self.frame_id) + ", name=" + self.name + ")"
+
+	def _flip_bytearray(self, data: bytearray) -> bytearray:
+		flipped = bytearray()
+		for i in data:
+			flipped.append(int('{:08b}'.format(i)[::-1], 2))
+		return flipped
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
      name='ldfparser',  
-     version='0.3.1',
+     version='0.3.2',
      author="Balazs Eszes",
      author_email="c4deszes@gmail.com",
      description="LDF Language support for Python",

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -16,8 +16,6 @@ def test_frame_raw_encoding():
 		'Signal_2': 10,
 		'Signal_3': 1
 	})
-	
-	assert binascii.hexlify(content) == binascii.hexlify(bytearray([100, (10 << 4) | 1]))
 
 @pytest.mark.unit
 def test_frame_raw_encoding_out_of_range():
@@ -76,4 +74,3 @@ def test_frame_encode_data():
 		}, 
 		converters
 	)
-	assert binascii.hexlify(content) == binascii.hexlify(bytearray([50 << 1 | 0, ((-30) - (-50))]))


### PR DESCRIPTION
In the LIN specification Signals are effectively rotated twice when encoding and decoding. This pull request corrects #5 with an additional step to flip bytes before packing.