### PR TITLE
Adds support for multiple slaves in LDF

### DIFF
--- a/ldfparser/ldf.lark
+++ b/ldfparser/ldf.lark
@@ -47,8 +47,11 @@ ldf_encoding_phy_unit: ESCAPED_STRING
 ?ldf_signal_representation: "Signal_representation" "{" [ldf_signal_representation_node*] "}" 
 ?ldf_signal_representation_node: ldf_signal_encoding_type_name ":" ldf_signal_name ("," ldf_signal_name)* ";"
 
-?ldf_node_master: "Master:" ldf_node_name "," /.*;/  
-?ldf_node_slaves: "Slaves:" ldf_node_name? ";" 
+?ldf_node_master: "Master:" ldf_node_name "," ldf_node_master_timebase "," ldf_node_master_jitter ";"  
+?ldf_node_slaves: "Slaves:" ldf_node_name? ["," ldf_node_name]* ";" 
+
+ldf_node_master_timebase: C_FLOAT "ms"
+ldf_node_master_jitter: C_FLOAT "ms"
 
 ldf_node : ldf_signal_name  ":" ldf_node_name ";" 
 ldf_signal :  ldf_signal_name ":" ldf_signal_size "," ldf_signal_default_value "," ldf_node_name "," ldf_node_name ";" 

--- a/tests/ldf/valid.ldf
+++ b/tests/ldf/valid.ldf
@@ -11,7 +11,7 @@ LIN_speed = 19.2 kbps ;
 
 Nodes {
   Master: Master, 5 ms, 0.1 ms ;
-  Slaves: Slave ;
+  Slaves: Slave1, Slave2, Slave3;
 }
 
 Signals{
@@ -34,7 +34,7 @@ Frames{
 }
 
 Node_attributes {
-	Slave{
+	Slave1 {
 		LIN_protocol = "2.1" ;
 		configured_NAD = 0x1 ;
 		initial_NAD = 0x1 ;


### PR DESCRIPTION
Fixed only one slave being allowed in the "Slaves" field of the LDF
Added extra fields for timebase and jitter in the "Master" field of LDF
Updated valid.ldf file to include multiple slaves

Fixes issue [uCAN-LIN/LinUSBConverter#5](https://github.com/uCAN-LIN/LinUSBConverter/issues/5)