### PR TITLE
Use recommended comment regex by lark

### DIFF
--- a/ldfparser/comment.lark
+++ b/ldfparser/comment.lark
@@ -1,11 +1,12 @@
 start: (comment)*
 
 comment: line_comment | block_comment
-line_comment: LINE_COMMENT
-block_comment: BLOCK_COMMENT
+line_comment: CPP_COMMENT
+block_comment: C_COMMENT
 
-LINE_COMMENT: /\/\/[^\n]*/
-BLOCK_COMMENT: "/*" /(.|\n)*/ "*/"
+// Use common.CPP_COMMENT and common.C_COMMENT once lark-parser v0.10.2 is released
+CPP_COMMENT: /\/\/[^\n]*/
+C_COMMENT: "/*" /.*?/s "*/"
 NOT_COMMENT: /(?!((\/\/)|(\/\*)))[^\n]]*/
 NEWLINE: /\r?\n/
 

--- a/ldfparser/ldf.lark
+++ b/ldfparser/ldf.lark
@@ -107,6 +107,7 @@ C_FLOAT: "-"? INT ("." INT)?
 
 ANY_SEMICOLON_TERMINATED_LINE: /.*;/
 
+// Use common.CPP_COMMENT and common.C_COMMENT once lark-parser v0.10.2 is released
 CPP_COMMENT: /\/\/[^\n]*/
 C_COMMENT: "/*" /.*?/s "*/"
 

--- a/ldfparser/ldf.lark
+++ b/ldfparser/ldf.lark
@@ -105,13 +105,13 @@ signal_representation_node: ldf_identifier ":" ldf_identifier ("," ldf_identifie
 C_INT: ("0x"HEXDIGIT+) | ("-"? INT) 
 C_FLOAT: "-"? INT ("." INT)?
 
-BLOCK_COMMENT: "/*" /(.|\n)*/ "*/"
-LINE_COMMENT: /\/\/.*/
-
 ANY_SEMICOLON_TERMINATED_LINE: /.*;/
 
-%ignore LINE_COMMENT
-%ignore BLOCK_COMMENT
+CPP_COMMENT: /\/\/[^\n]*/
+C_COMMENT: "/*" /.*?/s "*/"
+
+%ignore CPP_COMMENT
+%ignore C_COMMENT
 %ignore WS
 %ignore WS_INLINE
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lark-parser
+lark-parser>=0.10.0
 bitstruct

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
      package_data = { '': ['*.lark'] },
      license = 'MIT',
      keywords = ['LIN', 'LDF'],
-     install_requires = ['lark-parser', 'bitstruct'],
+     install_requires = ['lark-parser>=0.10.0', 'bitstruct'],
      python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
      py_modules=['lin','parser'],
      classifiers=[


### PR DESCRIPTION
* Use recommended comment regex by lark. See https://github.com/lark-parser/lark/blob/master/lark/grammars/common.lark#L58
There are edge cases where the existing regex fail, and the one recommended by lark pass