### PR TITLE
Better coverage for JSON output

### DIFF
--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -350,7 +350,7 @@ class LDFTransformer(Transformer):
 		return {"type": "assign_frame_id_range"} #TODO: add arguments
 
 	def schedule_table_command_assignframeid(self, tree):
-		return {"type": "assign_frame_id"} # TODO: add arguments
+		return {"type": "assign_frame_id", "node": tree[0], "frame": tree[1]}
 
 	def schedule_table_command_freeformat(self, tree):
 		return {"type": "free_format", "data": tree[0:]}

--- a/tests/ldf/lin13.json
+++ b/tests/ldf/lin13.json
@@ -1,0 +1,976 @@
+{
+	"frames": [
+		{
+			"frame_id": 32,
+			"length": 3,
+			"name": "VL1_CEM_Frm1",
+			"publisher": "CEM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "RearFogLampInd"
+				},
+				{
+					"offset": 1,
+					"signal": "PositionLampInd"
+				},
+				{
+					"offset": 2,
+					"signal": "FrontFogLampInd"
+				},
+				{
+					"offset": 3,
+					"signal": "IgnitionKeyPos"
+				},
+				{
+					"offset": 8,
+					"signal": "LSMFuncIllum"
+				},
+				{
+					"offset": 12,
+					"signal": "LSMSymbolIllum"
+				},
+				{
+					"offset": 16,
+					"signal": "StartHeater"
+				}
+			]
+		},
+		{
+			"frame_id": 48,
+			"length": null,
+			"name": "VL1_CEM_Frm2",
+			"publisher": "CEM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "CPMReqB0"
+				},
+				{
+					"offset": 8,
+					"signal": "CPMReqB1"
+				},
+				{
+					"offset": 16,
+					"signal": "CPMReqB2"
+				},
+				{
+					"offset": 24,
+					"signal": "CPMReqB3"
+				},
+				{
+					"offset": 32,
+					"signal": "CPMReqB4"
+				},
+				{
+					"offset": 40,
+					"signal": "CPMReqB5"
+				},
+				{
+					"offset": 48,
+					"signal": "CPMReqB6"
+				},
+				{
+					"offset": 56,
+					"signal": "CPMReqB7"
+				}
+			]
+		},
+		{
+			"frame_id": 33,
+			"length": null,
+			"name": "VL1_LSM_Frm1",
+			"publisher": "LSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "ReostatPos"
+				},
+				{
+					"offset": 4,
+					"signal": "HeadLampBeamLev"
+				},
+				{
+					"offset": 8,
+					"signal": "FrontFogLampSw"
+				},
+				{
+					"offset": 9,
+					"signal": "RearFogLampSw"
+				},
+				{
+					"offset": 10,
+					"signal": "MLSOff"
+				},
+				{
+					"offset": 11,
+					"signal": "MLSHeadLight"
+				},
+				{
+					"offset": 12,
+					"signal": "MLSPosLight"
+				},
+				{
+					"offset": 16,
+					"signal": "HBLSortHigh"
+				},
+				{
+					"offset": 17,
+					"signal": "HBLShortLow"
+				},
+				{
+					"offset": 18,
+					"signal": "ReoShortHigh"
+				},
+				{
+					"offset": 19,
+					"signal": "ReoShortLow"
+				}
+			]
+		},
+		{
+			"frame_id": 49,
+			"length": 6,
+			"name": "VL1_LSM_Frm2",
+			"publisher": "LSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "LSMHWPartNoB0"
+				},
+				{
+					"offset": 8,
+					"signal": "LSMHWPartNoB1"
+				},
+				{
+					"offset": 16,
+					"signal": "LSMHWPartNoB2"
+				},
+				{
+					"offset": 32,
+					"signal": "LSMHWPartNoB3"
+				},
+				{
+					"offset": 40,
+					"signal": "LSMSWPartNo"
+				}
+			]
+		},
+		{
+			"frame_id": 50,
+			"length": null,
+			"name": "VL1_CPM_Frm1",
+			"publisher": "CPM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "CPMOutputs"
+				},
+				{
+					"offset": 10,
+					"signal": "HeaterStatus"
+				},
+				{
+					"offset": 16,
+					"signal": "CPMGlowPlug"
+				},
+				{
+					"offset": 24,
+					"signal": "CPMFanPWM"
+				},
+				{
+					"offset": 32,
+					"signal": "WaterTempLow"
+				},
+				{
+					"offset": 40,
+					"signal": "WaterTempHigh"
+				},
+				{
+					"offset": 56,
+					"signal": "CPMFuelPump"
+				}
+			]
+		},
+		{
+			"frame_id": 34,
+			"length": null,
+			"name": "VL1_CPM_Frm2",
+			"publisher": "CPM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "CPMRunTime"
+				},
+				{
+					"offset": 16,
+					"signal": "FanIdealSpeed"
+				},
+				{
+					"offset": 24,
+					"signal": "FanMeasSpeed"
+				}
+			]
+		},
+		{
+			"frame_id": 51,
+			"length": null,
+			"name": "VL1_CPM_Frm3",
+			"publisher": "CPM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "CPMRespB0"
+				},
+				{
+					"offset": 8,
+					"signal": "CPMRespB1"
+				},
+				{
+					"offset": 16,
+					"signal": "CPMRespB2"
+				},
+				{
+					"offset": 24,
+					"signal": "CPMRespB3"
+				},
+				{
+					"offset": 32,
+					"signal": "CPMRespB4"
+				},
+				{
+					"offset": 40,
+					"signal": "CPMRespB5"
+				},
+				{
+					"offset": 48,
+					"signal": "CPMRespB6"
+				},
+				{
+					"offset": 56,
+					"signal": "CPMRespB7"
+				}
+			]
+		}
+	],
+	"header": "lin_description_file",
+	"language_version": 1.3,
+	"nodes": {
+		"master": {
+			"jitter": 0.0001,
+			"name": "CEM",
+			"timebase": 0.005
+		},
+		"slaves": [
+			"LSM",
+			"CPM"
+		]
+	},
+	"protocol_version": 1.3,
+	"schedule_tables": [
+		{
+			"name": "VL1_ST1",
+			"schedule": [
+				{
+					"command": {
+						"frame": "VL1_CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "VL1_LSM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "VL1_CPM_Frm1",
+						"type": "frame"
+					},
+					"delay": 20.0
+				},
+				{
+					"command": {
+						"frame": "VL1_CPM_Frm2",
+						"type": "frame"
+					},
+					"delay": 20.0
+				}
+			]
+		},
+		{
+			"name": "VL1_ST2",
+			"schedule": [
+				{
+					"command": {
+						"frame": "VL1_CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "VL1_CEM_Frm2",
+						"type": "frame"
+					},
+					"delay": 20.0
+				},
+				{
+					"command": {
+						"frame": "VL1_LSM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "VL1_LSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 20.0
+				},
+				{
+					"command": {
+						"frame": "VL1_CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "VL1_CPM_Frm1",
+						"type": "frame"
+					},
+					"delay": 20.0
+				},
+				{
+					"command": {
+						"frame": "VL1_CPM_Frm2",
+						"type": "frame"
+					},
+					"delay": 20.0
+				},
+				{
+					"command": {
+						"frame": "VL1_LSM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "VL1_CPM_Frm3",
+						"type": "frame"
+					},
+					"delay": 20.0
+				}
+			]
+		}
+	],
+	"signal_encoding_types": [
+		{
+			"name": "State1",
+			"values": [
+				{
+					"text": "off",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "on",
+					"type": "logical",
+					"value": 1
+				}
+			]
+		},
+		{
+			"name": "State2",
+			"values": [
+				{
+					"text": "off",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "on",
+					"type": "logical",
+					"value": 1
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 2
+				},
+				{
+					"text": "void",
+					"type": "logical",
+					"value": 3
+				}
+			]
+		},
+		{
+			"name": "Temp",
+			"values": [
+				{
+					"max": 250,
+					"min": 0,
+					"offset": -40.0,
+					"scale": 0.5,
+					"type": "physical",
+					"unit": "degree"
+				},
+				{
+					"max": 253,
+					"min": 251,
+					"offset": 0.0,
+					"scale": 1.0,
+					"type": "physical",
+					"unit": "undefined"
+				},
+				{
+					"text": "out of range",
+					"type": "logical",
+					"value": 254
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 255
+				}
+			]
+		},
+		{
+			"name": "Speed",
+			"values": [
+				{
+					"max": 65500,
+					"min": 0,
+					"offset": 250.0,
+					"scale": 0.008,
+					"type": "physical",
+					"unit": "km/h"
+				},
+				{
+					"max": 65533,
+					"min": 65501,
+					"offset": 0.0,
+					"scale": 1.0,
+					"type": "physical",
+					"unit": "undefined"
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 65534
+				},
+				{
+					"text": "void",
+					"type": "logical",
+					"value": 65535
+				}
+			]
+		}
+	],
+	"signal_groups": [
+		{
+			"name": "CPMReq",
+			"signals": {
+				"CPMReqB0": 0,
+				"CPMReqB1": 8,
+				"CPMReqB2": 16,
+				"CPMReqB3": 24,
+				"CPMReqB4": 32,
+				"CPMReqB5": 40,
+				"CPMReqB6": 48,
+				"CPMReqB7": 56
+			},
+			"size": 64
+		},
+		{
+			"name": "CPMResp",
+			"signals": {
+				"CPMRespB0": 0,
+				"CPMRespB1": 8,
+				"CPMRespB2": 16,
+				"CPMRespB3": 24,
+				"CPMRespB4": 32,
+				"CPMRespB5": 40,
+				"CPMRespB6": 48,
+				"CPMRespB7": 56
+			},
+			"size": 64
+		}
+	],
+	"signal_representations": [
+		{
+			"encoding": "State1",
+			"signals": [
+				"RearFogLampInd",
+				"PositionLampInd",
+				"FrontFogLampInd"
+			]
+		},
+		{
+			"encoding": "Temp",
+			"signals": [
+				"WaterTempLow",
+				"WaterTempHigh"
+			]
+		},
+		{
+			"encoding": "Speed",
+			"signals": [
+				"FanIdealSpeed",
+				"FanMeasSpeed"
+			]
+		}
+	],
+	"signals": [
+		{
+			"init_value": 0,
+			"name": "RearFogLampInd",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "PositionLampInd",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "FrontFogLampInd",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "IgnitionKeyPos",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM",
+				"CPM"
+			],
+			"width": 3
+		},
+		{
+			"init_value": 0,
+			"name": "LSMFuncIllum",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM"
+			],
+			"width": 4
+		},
+		{
+			"init_value": 0,
+			"name": "LSMSymbolIllum",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM"
+			],
+			"width": 4
+		},
+		{
+			"init_value": 0,
+			"name": "StartHeater",
+			"publisher": "CEM",
+			"subscribers": [
+				"CPM"
+			],
+			"width": 3
+		},
+		{
+			"init_value": 0,
+			"name": "CPMReqB0",
+			"publisher": "CEM",
+			"subscribers": [
+				"CPM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMReqB1",
+			"publisher": "CEM",
+			"subscribers": [
+				"CPM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMReqB2",
+			"publisher": "CEM",
+			"subscribers": [
+				"CPM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMReqB3",
+			"publisher": "CEM",
+			"subscribers": [
+				"CMP"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMReqB4",
+			"publisher": "CEM",
+			"subscribers": [
+				"CPM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMReqB5",
+			"publisher": "CEM",
+			"subscribers": [
+				"CPM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMReqB6",
+			"publisher": "CEM",
+			"subscribers": [
+				"CPM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMReqB7",
+			"publisher": "CEM",
+			"subscribers": [
+				"CPM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "ReostatPos",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 4
+		},
+		{
+			"init_value": 0,
+			"name": "HeadLampBeamLev",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 4
+		},
+		{
+			"init_value": 0,
+			"name": "FrontFogLampSw",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "RearFogLampSw",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "MLSOff",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "MLSHeadLight",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "MLSPosLight",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "HBLSortHigh",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "HBLShortLow",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "ReoShortHigh",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "ReoShortLow",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "LSMHWPartNoB0",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "LSMHWPartNoB1",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "LSMHWPartNoB2",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "LSMHWPartNoB3",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "LSMSWPartNo",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMOutputs",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 10
+		},
+		{
+			"init_value": 0,
+			"name": "HeaterStatus",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 4
+		},
+		{
+			"init_value": 0,
+			"name": "CPMGlowPlug",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 7
+		},
+		{
+			"init_value": 0,
+			"name": "CPMFanPWM",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "WaterTempLow",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "WaterTempHigh",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMFuelPump",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 7
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRunTime",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 13
+		},
+		{
+			"init_value": 0,
+			"name": "FanIdealSpeed",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "FanMeasSpeed",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRespB0",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRespB1",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRespB2",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRespB3",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRespB4",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRespB5",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRespB6",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "CPMRespB7",
+			"publisher": "CPM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		}
+	],
+	"speed": 19200
+}

--- a/tests/ldf/lin20.json
+++ b/tests/ldf/lin20.json
@@ -1,0 +1,126 @@
+{
+	"frames": [
+		{
+			"frame_id": 1,
+			"length": null,
+			"name": "VL1_CEM_Frm1",
+			"publisher": "CEM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "InternalLightsRequest"
+				}
+			]
+		},
+		{
+			"frame_id": 2,
+			"length": null,
+			"name": "VL1_LSM_Frm1",
+			"publisher": "LSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "InternalLightsSwitch"
+				}
+			]
+		}
+	],
+	"header": "lin_description_file",
+	"language_version": 2.0,
+	"node_attributes": [
+		{
+			"configured_nad": 1,
+			"lin_protocol": 2.0,
+			"name": "LSM"
+		}
+	],
+	"nodes": {
+		"master": {
+			"jitter": 0.0001,
+			"name": "CEM",
+			"timebase": 0.005
+		},
+		"slaves": [
+			"LSM"
+		]
+	},
+	"protocol_version": 2.0,
+	"schedule_tables": [
+		{
+			"name": "MySchedule1",
+			"schedule": [
+				{
+					"command": {
+						"frame": "VL1_CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "VL1_LSM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				}
+			]
+		}
+	],
+	"signal_encoding_types": [
+		{
+			"name": "Dig2Bit",
+			"values": [
+				{
+					"text": "off",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "on",
+					"type": "logical",
+					"value": 1
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 2
+				},
+				{
+					"text": "void",
+					"type": "logical",
+					"value": 3
+				}
+			]
+		}
+	],
+	"signal_representations": [
+		{
+			"encoding": "Dig2Bit",
+			"signals": [
+				"InternalLightsRequest",
+				"InternalLightsSwitch"
+			]
+		}
+	],
+	"signals": [
+		{
+			"init_value": 0,
+			"name": "InternalLightsRequest",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM"
+			],
+			"width": 2
+		},
+		{
+			"init_value": 0,
+			"name": "InternalLightsSwitch",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 2
+		}
+	],
+	"speed": 19200
+}

--- a/tests/ldf/lin21.json
+++ b/tests/ldf/lin21.json
@@ -1,0 +1,466 @@
+{
+	"channel_name": "DB",
+	"event_triggered_frames": [
+		{
+			"name": "Node_Status_Event"
+		}
+	],
+	"frames": [
+		{
+			"frame_id": 1,
+			"length": 1,
+			"name": "CEM_Frm1",
+			"publisher": "CEM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "InternalLightsRequest"
+				}
+			]
+		},
+		{
+			"frame_id": 2,
+			"length": 2,
+			"name": "LSM_Frm1",
+			"publisher": "LSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "LeftIntLightsSwitch"
+				}
+			]
+		},
+		{
+			"frame_id": 3,
+			"length": 1,
+			"name": "LSM_Frm2",
+			"publisher": "LSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "LSMerror"
+				},
+				{
+					"offset": 1,
+					"signal": "IntError"
+				}
+			]
+		},
+		{
+			"frame_id": 4,
+			"length": 2,
+			"name": "RSM_Frm1",
+			"publisher": "RSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "RightIntLightsSwitch"
+				}
+			]
+		},
+		{
+			"frame_id": 5,
+			"length": 1,
+			"name": "RSM_Frm2",
+			"publisher": "RSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "RSMerror"
+				}
+			]
+		}
+	],
+	"header": "lin_description_file",
+	"language_version": 2.1,
+	"node_attributes": [
+		{
+			"P2_min": 0.15,
+			"ST_min": 0.05,
+			"configurable_frames": [
+				"CEM_Frm1",
+				"LSM_Frm1",
+				"LSM_Frm2"
+			],
+			"configured_nad": 32,
+			"fault_state_signals": [
+				"IntError"
+			],
+			"initial_nad": 1,
+			"lin_protocol": 2.1,
+			"name": "LSM",
+			"product_id": {
+				"function_id": 18497,
+				"supplier_id": 19023,
+				"variant": null
+			},
+			"response_error": "LSMerror"
+		},
+		{
+			"P2_min": 0.15,
+			"ST_min": 0.05,
+			"configurable_frames": {
+				"CEM_Frm1": 1,
+				"LSM_Frm1": 2,
+				"LSM_Frm2": 3
+			},
+			"configured_nad": 32,
+			"lin_protocol": 2.0,
+			"name": "RSM",
+			"product_id": {
+				"function_id": 17747,
+				"supplier_id": 20046,
+				"variant": 1
+			},
+			"response_error": "RSMerror"
+		}
+	],
+	"nodes": {
+		"master": {
+			"jitter": 0.0001,
+			"name": "CEM",
+			"timebase": 0.005
+		},
+		"slaves": [
+			"LSM",
+			"RSM"
+		]
+	},
+	"protocol_version": 2.1,
+	"schedule_tables": [
+		{
+			"name": "Configuration_Schedule",
+			"schedule": [
+				{
+					"command": {
+						"node": "LSM",
+						"type": "assign_nad"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"type": "assign_frame_id_range"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "CEM_Frm1",
+						"node": "RSM",
+						"type": "assign_frame_id"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm1",
+						"node": "RSM",
+						"type": "assign_frame_id"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm2",
+						"node": "RSM",
+						"type": "assign_frame_id"
+					},
+					"delay": 15.0
+				}
+			]
+		},
+		{
+			"name": "Normal_Schedule",
+			"schedule": [
+				{
+					"command": {
+						"frame": "CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "LSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "Node_Status_Event",
+						"type": "frame"
+					},
+					"delay": 10.0
+				}
+			]
+		},
+		{
+			"name": "MRF_schedule",
+			"schedule": [
+				{
+					"command": {
+						"type": "master_request"
+					},
+					"delay": 10.0
+				}
+			]
+		},
+		{
+			"name": "SRF_schedule",
+			"schedule": [
+				{
+					"command": {
+						"type": "slave_response"
+					},
+					"delay": 10.0
+				}
+			]
+		},
+		{
+			"name": "Collision_resolver",
+			"schedule": [
+				{
+					"command": {
+						"frame": "CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "LSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm1",
+						"type": "frame"
+					},
+					"delay": 10.0
+				},
+				{
+					"command": {
+						"frame": "CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "LSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "LSM_Frm1",
+						"type": "frame"
+					},
+					"delay": 10.0
+				}
+			]
+		}
+	],
+	"signal_encoding_types": [
+		{
+			"name": "Dig2Bit",
+			"values": [
+				{
+					"text": "off",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "on",
+					"type": "logical",
+					"value": 1
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 2
+				},
+				{
+					"text": "void",
+					"type": "logical",
+					"value": 3
+				}
+			]
+		},
+		{
+			"name": "ErrorEncoding",
+			"values": [
+				{
+					"text": "OK",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 1
+				}
+			]
+		},
+		{
+			"name": "FaultStateEncoding",
+			"values": [
+				{
+					"text": "No test result",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "failed",
+					"type": "logical",
+					"value": 1
+				},
+				{
+					"text": "passed",
+					"type": "logical",
+					"value": 2
+				},
+				{
+					"text": "not used",
+					"type": "logical",
+					"value": 3
+				}
+			]
+		},
+		{
+			"name": "LightEncoding",
+			"values": [
+				{
+					"text": "Off",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"max": 254,
+					"min": 1,
+					"offset": 100.0,
+					"scale": 1.0,
+					"type": "physical",
+					"unit": "lux"
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 255
+				}
+			]
+		}
+	],
+	"signal_representations": [
+		{
+			"encoding": "Dig2Bit",
+			"signals": [
+				"InternalLightsRequest"
+			]
+		},
+		{
+			"encoding": "ErrorEncoding",
+			"signals": [
+				"RSMerror",
+				"LSMerror"
+			]
+		},
+		{
+			"encoding": "FaultStateEncoding",
+			"signals": [
+				"IntError"
+			]
+		},
+		{
+			"encoding": "LightEncoding",
+			"signals": [
+				"RightIntLightsSwitch",
+				"LefttIntLightsSwitch"
+			]
+		}
+	],
+	"signals": [
+		{
+			"init_value": 0,
+			"name": "InternalLightsRequest",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM",
+				"RSM"
+			],
+			"width": 2
+		},
+		{
+			"init_value": 0,
+			"name": "RightIntLightsSwitch",
+			"publisher": "RSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "LeftIntLightsSwitch",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "LSMerror",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "RSMerror",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "IntError",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 2
+		}
+	],
+	"speed": 19200
+}

--- a/tests/ldf/lin22.json
+++ b/tests/ldf/lin22.json
@@ -1,0 +1,468 @@
+{
+	"channel_name": "DB",
+	"event_triggered_frames": [
+		{
+			"name": "Node_Status_Event"
+		}
+	],
+	"frames": [
+		{
+			"frame_id": 1,
+			"length": 1,
+			"name": "CEM_Frm1",
+			"publisher": "CEM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "InternalLightsRequest"
+				}
+			]
+		},
+		{
+			"frame_id": 2,
+			"length": 2,
+			"name": "LSM_Frm1",
+			"publisher": "LSM",
+			"signals": [
+				{
+					"offset": 8,
+					"signal": "LeftIntLightsSwitch"
+				}
+			]
+		},
+		{
+			"frame_id": 3,
+			"length": 1,
+			"name": "LSM_Frm2",
+			"publisher": "LSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "LSMerror"
+				},
+				{
+					"offset": 1,
+					"signal": "IntTest"
+				}
+			]
+		},
+		{
+			"frame_id": 4,
+			"length": 2,
+			"name": "RSM_Frm1",
+			"publisher": "RSM",
+			"signals": [
+				{
+					"offset": 8,
+					"signal": "RightIntLightsSwitch"
+				}
+			]
+		},
+		{
+			"frame_id": 5,
+			"length": 1,
+			"name": "RSM_Frm2",
+			"publisher": "RSM",
+			"signals": [
+				{
+					"offset": 0,
+					"signal": "RSMerror"
+				}
+			]
+		}
+	],
+	"header": "lin_description_file",
+	"language_version": 2.2,
+	"node_attributes": [
+		{
+			"P2_min": 0.15,
+			"ST_min": 0.05,
+			"configurable_frames": {
+				"CEM_Frm1": 1,
+				"Node_Status_Event": 0,
+				"RSM_Frm1": 2,
+				"RSM_Frm2": 3
+			},
+			"configured_nad": 32,
+			"lin_protocol": 2.0,
+			"name": "RSM",
+			"product_id": {
+				"function_id": 17747,
+				"supplier_id": 20046,
+				"variant": 1
+			},
+			"response_error": "RSMerror"
+		},
+		{
+			"P2_min": 0.15,
+			"ST_min": 0.05,
+			"configurable_frames": [
+				"Node_Status_Event",
+				"CEM_Frm1",
+				"LSM_Frm1",
+				"LSM_Frm2"
+			],
+			"configured_nad": 33,
+			"fault_state_signals": [
+				"IntTest"
+			],
+			"initial_nad": 1,
+			"lin_protocol": 2.2,
+			"name": "LSM",
+			"product_id": {
+				"function_id": 18497,
+				"supplier_id": 19023,
+				"variant": null
+			},
+			"response_error": "LSMerror"
+		}
+	],
+	"nodes": {
+		"master": {
+			"jitter": 0.0001,
+			"name": "CEM",
+			"timebase": 0.005
+		},
+		"slaves": [
+			"LSM",
+			"RSM"
+		]
+	},
+	"protocol_version": 2.2,
+	"schedule_tables": [
+		{
+			"name": "Configuration_Schedule",
+			"schedule": [
+				{
+					"command": {
+						"node": "LSM",
+						"type": "assign_nad"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"type": "assign_frame_id_range"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "CEM_Frm1",
+						"node": "RSM",
+						"type": "assign_frame_id"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm1",
+						"node": "RSM",
+						"type": "assign_frame_id"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm2",
+						"node": "RSM",
+						"type": "assign_frame_id"
+					},
+					"delay": 15.0
+				}
+			]
+		},
+		{
+			"name": "Normal_Schedule",
+			"schedule": [
+				{
+					"command": {
+						"frame": "CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "LSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "Node_Status_Event",
+						"type": "frame"
+					},
+					"delay": 10.0
+				}
+			]
+		},
+		{
+			"name": "MRF_schedule",
+			"schedule": [
+				{
+					"command": {
+						"type": "master_request"
+					},
+					"delay": 10.0
+				}
+			]
+		},
+		{
+			"name": "SRF_schedule",
+			"schedule": [
+				{
+					"command": {
+						"type": "slave_response"
+					},
+					"delay": 10.0
+				}
+			]
+		},
+		{
+			"name": "Collision_resolver",
+			"schedule": [
+				{
+					"command": {
+						"frame": "CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "LSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm1",
+						"type": "frame"
+					},
+					"delay": 10.0
+				},
+				{
+					"command": {
+						"frame": "CEM_Frm1",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "LSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "RSM_Frm2",
+						"type": "frame"
+					},
+					"delay": 15.0
+				},
+				{
+					"command": {
+						"frame": "LSM_Frm1",
+						"type": "frame"
+					},
+					"delay": 10.0
+				}
+			]
+		}
+	],
+	"signal_encoding_types": [
+		{
+			"name": "Dig2Bit",
+			"values": [
+				{
+					"text": "off",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "on",
+					"type": "logical",
+					"value": 1
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 2
+				},
+				{
+					"text": "void",
+					"type": "logical",
+					"value": 3
+				}
+			]
+		},
+		{
+			"name": "ErrorEncoding",
+			"values": [
+				{
+					"text": "OK",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 1
+				}
+			]
+		},
+		{
+			"name": "FaultStateEncoding",
+			"values": [
+				{
+					"text": "No test result",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"text": "failed",
+					"type": "logical",
+					"value": 1
+				},
+				{
+					"text": "passed",
+					"type": "logical",
+					"value": 2
+				},
+				{
+					"text": "not used",
+					"type": "logical",
+					"value": 3
+				}
+			]
+		},
+		{
+			"name": "LightEncoding",
+			"values": [
+				{
+					"text": "Off",
+					"type": "logical",
+					"value": 0
+				},
+				{
+					"max": 254,
+					"min": 1,
+					"offset": 100.0,
+					"scale": 1.0,
+					"type": "physical",
+					"unit": "lux"
+				},
+				{
+					"text": "error",
+					"type": "logical",
+					"value": 255
+				}
+			]
+		}
+	],
+	"signal_representations": [
+		{
+			"encoding": "Dig2Bit",
+			"signals": [
+				"InternalLightsRequest"
+			]
+		},
+		{
+			"encoding": "ErrorEncoding",
+			"signals": [
+				"RSMerror",
+				"LSMerror"
+			]
+		},
+		{
+			"encoding": "FaultStateEncoding",
+			"signals": [
+				"IntError"
+			]
+		},
+		{
+			"encoding": "LightEncoding",
+			"signals": [
+				"RightIntLightsSwitch",
+				"LefttIntLightsSwitch"
+			]
+		}
+	],
+	"signals": [
+		{
+			"init_value": 0,
+			"name": "InternalLightsRequest",
+			"publisher": "CEM",
+			"subscribers": [
+				"LSM",
+				"RSM"
+			],
+			"width": 2
+		},
+		{
+			"init_value": 0,
+			"name": "RightIntLightsSwitch",
+			"publisher": "RSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "LeftIntLightsSwitch",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 8
+		},
+		{
+			"init_value": 0,
+			"name": "LSMerror",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "RSMerror",
+			"publisher": "RSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 1
+		},
+		{
+			"init_value": 0,
+			"name": "IntTest",
+			"publisher": "LSM",
+			"subscribers": [
+				"CEM"
+			],
+			"width": 2
+		}
+	],
+	"speed": 19200
+}

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,34 @@
+from os.path import dirname, basename, splitext, join
+from pathlib import Path
+import pytest
+import ldfparser
+import json
+import glob
+from difflib import unified_diff
+
+# For development purposes only
+AUTO_APPROVE = False
+
+ldf_dir = join(dirname(__file__), 'ldf')
+ldf_files = [basename(f) for f in glob.glob(ldf_dir + '/*.ldf')]
+
+@pytest.mark.parametrize('path', ldf_files)
+def test_json_valid(path):
+	ldf_path = join(ldf_dir, path)
+	json_path = splitext(ldf_path)[0] + '.json'
+
+	data = ldfparser.parseLDFtoDict(ldf_path)
+
+	received = json.dumps(data, indent='\t', sort_keys=True)
+	
+	if AUTO_APPROVE:
+		Path(json_path).write_text(received)
+	
+	approved = Path(json_path).read_text()
+
+	diff = '\n'.join(unified_diff(approved.split('\n'), received.split('\n')))
+	has_diff = bool(diff)
+	assert not has_diff, 'Mismatch found in ' + path + ':\n' + diff
+
+	assert not AUTO_APPROVE, 'Disable AUTO_APPROVE'
+


### PR DESCRIPTION
* Use Snapshot testing to ensure any changes to the parser do not affect the JSON format unintentionally.
* YAML could be used instead of JSON for storing the generated file, in order to have a more concise output, but I didn't want to add an extra test dependency at this phase.

See https://github.com/approvals/ApprovalTests.Python and https://jestjs.io/docs/en/snapshot-testing