### PR TITLE
Allow signal with no subscribers and empty node attribute section

### DIFF
--- a/ldfparser/ldf.lark
+++ b/ldfparser/ldf.lark
@@ -25,7 +25,7 @@ node_compositions_composite: ldf_identifier "{" ldf_identifier ("," ldf_identifi
 
 // LIN 2.1 Specification, section 9.2.3
 signals: "Signals" "{" (signal_definition)+ "}"
-signal_definition: ldf_identifier ":" ldf_integer "," signal_default_value "," ldf_identifier ("," ldf_identifier)+ ";"
+signal_definition: ldf_identifier ":" ldf_integer "," signal_default_value "," ldf_identifier ("," ldf_identifier)* ";"
 signal_default_value: signal_default_value_array | signal_default_value_single
 signal_default_value_single: C_INT
 signal_default_value_array: "{" C_INT ("," C_INT)* "}"
@@ -53,7 +53,7 @@ diagnostic_frames: "Diagnostic_frames" "{" (diagnostic_frame_definition)+ "}"
 diagnostic_frame_definition: ldf_identifier ":" ldf_integer "{" (ANY_SEMICOLON_TERMINATED_LINE)* "}"
 
 // LIN 2.1 Specification, section 9.2.2.2
-node_attributes: "Node_attributes" "{" (node_definition+) "}"
+node_attributes: "Node_attributes" "{" (node_definition*) "}"
 node_definition: ldf_identifier "{" (node_definition_protocol | node_definition_configured_nad | node_definition_initial_nad | node_definition_product_id | node_definition_response_error | node_definition_fault_state_signals | node_definition_p2_min | node_definition_st_min | node_definition_n_as_timeout | node_definition_n_cr_timeout | node_definition_configurable_frames)* "}"
 node_definition_protocol: "LIN_protocol" "=" (["\"" ldf_float "\""] | ldf_float) ";"
 node_definition_configured_nad: "configured_NAD" "=" ldf_integer ";"

--- a/tests/ldf/no_signal_subscribers.ldf
+++ b/tests/ldf/no_signal_subscribers.ldf
@@ -1,0 +1,36 @@
+/* 
+  Here you will find an odd case that is not normally valid in the LIN specification,
+  However is commonly used by OEMs.
+  The DummyFrame serves as a "Keep Alive" so slaves don't go to sleep.
+*/
+
+LIN_description_file;
+LIN_protocol_version = "2.2";
+LIN_language_version = "2.2";
+LIN_speed =  19.2 kbps;
+
+Nodes {
+	Master: master, 5.0 ms, 0.1 ms;
+	Slaves: slave1;
+}
+
+Signals {
+	// Signal with no subscribers
+	DummySignal_0: 8, 255, master;
+}
+
+Frames {
+	DummyFrame: 59, master, 8 {
+		DummySignal_0, 0;
+	}
+}
+
+Node_attributes {
+	// Empty
+}
+
+Schedule_tables {
+	RUN_MAIN { 
+		DummyFrame delay 10.0 ms;
+	}
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -68,3 +68,15 @@ def test_load_valid_lin22():
 	converter = ldf.converters['InternalLightsRequest']
 	assert converter.name == 'Dig2Bit'
 	assert isinstance(converter._converters[0], LogicalValue)
+
+@pytest.mark.unit
+def test_no_signal_subscribers():
+	path = os.path.join(os.path.dirname(__file__), "ldf", "no_signal_subscribers.ldf")
+	ldf = ldfparser.parseLDF(path)
+
+	assert ldf.protocol_version == 2.2
+	assert ldf.language_version == 2.2
+	assert ldf.baudrate == 19200
+	
+	assert ldf.signal('DummySignal_0') is not None
+	assert ldf.frame('DummyFrame') is not None


### PR DESCRIPTION
Due to confidentiality I can't share the full LDF file, I only kept enough of it to reproduce the problem.