### PR TITLE
Fixes zero signal encoding behavior

### DIFF
--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -74,7 +74,7 @@ class LinFrame:
 		"""
 		message = []
 		for signal in self.signals:
-			if data.get(signal.name):
+			if signal.name in data.keys():
 				if signal.is_array():
 					message += data.get(signal.name)
 				else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.7.0
+version = 0.7.1

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -19,6 +19,34 @@ def test_frame_raw_encoding():
 
 	assert list(content) == [100, 10 | 1 << 7]
 
+@pytest.mark.unit
+def test_frame_raw_encoding_zero():
+	signal1 = LinSignal('Signal_1', 8, 255)
+	signal2 = LinSignal('Signal_2', 4, 15)
+	signal3 = LinSignal('Signal_3', 1, 1)
+
+	frame = LinFrame(1, 'Frame_1', 2, {0: signal1, 8: signal2, 15: signal3})
+	content = frame.raw({
+		'Signal_1': 0,
+		'Signal_2': 10,
+		'Signal_3': 1
+	})
+
+	assert list(content) == [0, 10 | 1 << 7]
+
+@pytest.mark.unit
+def test_frame_raw_encoding_no_signal():
+	signal1 = LinSignal('Signal_1', 8, 255)
+	signal2 = LinSignal('Signal_2', 4, 255)
+	signal3 = LinSignal('Signal_3', 1, 255)
+
+	frame = LinFrame(1, 'Frame_1', 2, {0: signal1, 8: signal2, 15: signal3})
+	content = frame.raw({
+		'Signal_2': 10,
+		'Signal_3': 1
+	})
+
+	assert list(content) == [255, 10 | 1 << 7]
 
 @pytest.mark.unit
 def test_frame_raw_encoding_array():

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -19,6 +19,7 @@ def test_frame_raw_encoding():
 
 	assert list(content) == [100, 10 | 1 << 7]
 
+
 @pytest.mark.unit
 def test_frame_raw_encoding_zero():
 	signal1 = LinSignal('Signal_1', 8, 255)
@@ -34,6 +35,7 @@ def test_frame_raw_encoding_zero():
 
 	assert list(content) == [0, 10 | 1 << 7]
 
+
 @pytest.mark.unit
 def test_frame_raw_encoding_no_signal():
 	signal1 = LinSignal('Signal_1', 8, 255)
@@ -47,6 +49,7 @@ def test_frame_raw_encoding_no_signal():
 	})
 
 	assert list(content) == [255, 10 | 1 << 7]
+
 
 @pytest.mark.unit
 def test_frame_raw_encoding_array():


### PR DESCRIPTION
## Brief

The logic for frame encoding now uses `in` instead of the `get` operator when checking whether a signal is specified in the data.

This issue was discovered by an external user.

## Fixes

+ Frame encoding zero valued signals incorrectly uses the initial value.

## Evidence

+ Previous coverage values were misleading, there were no tests for the "signal fallback" mechanism but the branches were covered because most of the tests used 0 as the initial value.
+ Added more tests to cover this scenario.