### PR TITLE
Adds JSON schema for LDF tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Standard JSON schema for parsed LDFs
+
 ### Fixed
 
 - Missing encoders causing `KeyError` instead of `ValueError`

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ wheel
 pytest
 pytest-cov
 flake8
+jsonschema

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -7,28 +7,28 @@
 			"type": "string",
 			"pattern": "lin_description_file"
 		},
-		"version" : {
+		"version": {
 			"type": "number",
-			"minimum": 0.0,
+			"minimum": 0,
 			"maximum": 2.2
 		},
 		"master": {
 			"type": "object",
 			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "timebase": {
-				"type": "number"
-			  },
-			  "jitter": {
-				"type": "number"
-			  }
+				"name": {
+					"type": "string"
+				},
+				"timebase": {
+					"type": "number"
+				},
+				"jitter": {
+					"type": "number"
+				}
 			},
 			"required": [
-			  "name",
-			  "timebase",
-			  "jitter"
+				"name",
+				"timebase",
+				"jitter"
 			]
 		},
 		"slaves": {
@@ -40,30 +40,30 @@
 		"signal": {
 			"type": "object",
 			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "width": {
-				"type": "integer"
-			  },
-			  "init_value": {
-				"type": "integer"
-			  },
-			  "publisher": {
-				"type": "string"
-			  },
-			  "subscribers": {
-				"type": "array",
-				"items": {
+				"name": {
 					"type": "string"
+				},
+				"width": {
+					"type": "integer"
+				},
+				"init_value": {
+					"type": "integer"
+				},
+				"publisher": {
+					"type": "string"
+				},
+				"subscribers": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				}
-			  }
 			},
 			"required": [
-			  "name",
-			  "width",
-			  "init_value",
-			  "publisher"
+				"name",
+				"width",
+				"init_value",
+				"publisher"
 			]
 		},
 		"frame": {
@@ -79,7 +79,10 @@
 					"type": "string"
 				},
 				"length": {
-					"type": ["integer", "null"]
+					"type": [
+						"integer",
+						"null"
+					]
 				},
 				"signals": {
 					"type": "array",
@@ -111,92 +114,287 @@
 		"event_triggered_frame": {
 			"type": "object",
 			"properties": {
-			  "name": {
-				"type": "string"
-			  }
+				"name": {
+					"type": "string"
+				}
 			},
 			"required": [
-			  "name"
+				"name"
 			]
 		},
 		"node": {
 			"type": "object",
 			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "lin_protocol": {
-				"type": "number"
-			  },
-			  "configured_nad": {
-				"type": "integer"
-			  },
-			  "initial_nad": {
-				"type": "integer"
-			  },
-			  "product_id": {
-				"type": "object",
-				"properties": {
-				  "supplier_id": {
-					"type": "integer"
-				  },
-				  "function_id": {
-					"type": "integer"
-				  },
-				  "variant": {
-					"type": "integer"
-				  }
+				"name": {
+					"type": "string"
 				},
-				"required": [
-				  "supplier_id",
-				  "function_id"
-				]
-			  },
-			  "response_error": {
-				"type": "string"
-			  },
-			  "fault_state_signals": {
-				"type": "array",
-				"items":{
+				"lin_protocol": {
+					"type": "number"
+				},
+				"configured_nad": {
+					"type": "integer"
+				},
+				"initial_nad": {
+					"type": "integer"
+				},
+				"product_id": {
+					"type": "object",
+					"properties": {
+						"supplier_id": {
+							"type": "integer"
+						},
+						"function_id": {
+							"type": "integer"
+						},
+						"variant": {
+							"type": "integer"
+						}
+					},
+					"required": [
+						"supplier_id",
+						"function_id"
+					]
+				},
+				"response_error": {
 					"type": "string"
+				},
+				"fault_state_signals": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"P2_min": {
+					"type": "number"
+				},
+				"ST_min": {
+					"type": "number"
+				},
+				"N_As_timeout": {
+					"type": "number"
+				},
+				"N_Cr_timeout": {
+					"type": "number"
+				},
+				"configurable_frames": {
+					"type": [
+						"array",
+						"object"
+					],
+					"items": {
+						"type": "string"
+					}
 				}
-			  },
-			  "P2_min": {
-				"type": "number"
-			  },
-			  "ST_min": {
-				"type": "number"
-			  },
-			  "N_As_timeout": {
-				"type": "number"
-			  },
-			  "N_Cr_timeout": {
-				"type": "number"
-			  },
-			  "configurable_frames": {
-				"type": ["array", "object"],
-				"items": {
-					"type": "string"
-				}
-			  }
 			},
 			"required": [
-			  "name",
-			  "lin_protocol",
-			  "configured_nad"
+				"name",
+				"lin_protocol",
+				"configured_nad"
 			]
+		},
+		"assign_nad_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "assign_nad"
+				},
+				"node": {
+					"type": "string"
+				}
+			}
+		},
+		"assign_frame_id_range_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "assign_frame_id_range"
+				},
+				"node": {
+					"type": "string"
+				},
+				"frame_index": {
+					"type": "integer"
+				},
+				"pids": {
+					"type": "array",
+					"items": {
+						"type": "integer"
+					}
+				}
+			}
+		},
+		"conditional_change_nad_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "conditional_change_nad"
+				},
+				"nad": {
+					"type": "integer"
+				},
+				"id": {
+					"type": "integer"
+				},
+				"byte": {
+					"type": "integer"
+				},
+				"mask": {
+					"type": "integer"
+				},
+				"inv": {
+					"type": "integer"
+				},
+				"new_nad": {
+					"type": "integer"
+				}
+			}
+		},
+		"data_dump_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "data_dump"
+				},
+				"node": {
+					"type": "string"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"type": "integer"
+					}
+				}
+			}
+		},
+		"save_configuration_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "save_configuration"
+				},
+				"node": {
+					"type": "string"
+				}
+			}
+		},
+		"assign_frame_id_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "assign_frame_id"
+				},
+				"node": {
+					"type": "string"
+				},
+				"frame": {
+					"type": "string"
+				}
+			}
+		},
+		"free_format_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "free_format"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"type": "integer"
+					}
+				}
+			}
+		},
+		"frame_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "frame"
+				},
+				"frame": {
+					"type": "string"
+				}
+			}
+		},
+		"master_request_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "master_request"
+				}
+			}
+		},
+		"slave_response_entry": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "slave_response"
+				}
+			}
+		},
+		"schedule_table_entry": {
+			"type": "object",
+			"properties": {
+				"command": {
+					"oneOf": [
+						{
+							"$ref": "#/definitions/assign_nad_entry"
+						},
+						{
+							"$ref": "#/definitions/assign_frame_id_range_entry"
+						},
+						{
+							"$ref": "#/definitions/conditional_change_nad_entry"
+						},
+						{
+							"$ref": "#/definitions/data_dump_entry"
+						},
+						{
+							"$ref": "#/definitions/save_configuration_entry"
+						},
+						{
+							"$ref": "#/definitions/assign_frame_id_entry"
+						},
+						{
+							"$ref": "#/definitions/free_format_entry"
+						},
+						{
+							"$ref": "#/definitions/frame_entry"
+						},
+						{
+							"$ref": "#/definitions/master_request_entry"
+						},
+						{
+							"$ref": "#/definitions/slave_response_entry"
+						}
+					]
+				},
+				"delay": {
+					"type": "integer"
+				}
+			}
 		},
 		"logical_value_encoder": {
 			"type": "object",
 			"properties": {
 				"type": {
-				"type": "string"
+					"type": "string"
 				},
 				"value": {
-				"type": "integer"
+					"type": "integer"
 				},
 				"text": {
-				"type": "string"
+					"type": "string"
 				}
 			},
 			"required": [
@@ -209,22 +407,22 @@
 			"type": "object",
 			"properties": {
 				"type": {
-				"type": "string"
+					"type": "string"
 				},
 				"min": {
-				"type": "number"
+					"type": "number"
 				},
 				"max": {
-				"type": "number"
+					"type": "number"
 				},
 				"scale": {
-				"type": "number"
+					"type": "number"
 				},
 				"offset": {
-				"type": "number"
+					"type": "number"
 				},
 				"unit": {
-				"type": "string"
+					"type": "string"
 				}
 			},
 			"required": [
@@ -238,115 +436,136 @@
 		}
 	},
 	"properties": {
-	  "header": {
-		"$ref": "#/definitions/header"
-	  },
-	  "protocol_version": {
-		"$ref": "#/definitions/version",
-		"description": ""
-	  },
-	  "language_version": {
-		"$ref": "#/definitions/version"
-	  },
-	  "speed": {
-		"type": "integer"
-	  },
-	  "channel_name": {
-		"type": "string"
-	  },
-	  "nodes": {
-		"type": "object",
-		"properties": {
-		  "master": {
-			"$ref": "#/definitions/master"
-		  },
-		  "slaves": {
-			"$ref": "#/definitions/slaves"
-		  }
+		"header": {
+			"$ref": "#/definitions/header"
 		},
-		"required": [
-		  "master",
-		  "slaves"
-		]
-	  },
-	  "signals": {
-		"type": "array",
-		"items": {
-			"$ref": "#/definitions/signal"
-		}
-	  },
-	  "frames": {
-		"type": "array",
-		"items": {
-			"$ref": "#/definitions/frame"
-		}
-	  },
-	  "event_triggered_frames": {
-		"type": "array",
-		"items": {
-			"$ref": "#/definitions/event_triggered_frame"
-		}
-	  },
-	  "node_attributes": {
-		"type": "array",
-		"items": {
-			"$ref": "#/definitions/node"
-		}
-	  },
-	  "signal_encoding_types": {
-		"type": "array",
-		"items": {
+		"protocol_version": {
+			"$ref": "#/definitions/version",
+			"description": ""
+		},
+		"language_version": {
+			"$ref": "#/definitions/version"
+		},
+		"speed": {
+			"type": "integer"
+		},
+		"channel_name": {
+			"type": "string"
+		},
+		"nodes": {
 			"type": "object",
 			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "values": {
-				"type": "array",
-				"items": {
-					"oneOf": [
-						{"$ref": "#/definitions/logical_value_encoder"},
-						{"$ref": "#/definitions/physical_value_encoder"}
-					]
+				"master": {
+					"$ref": "#/definitions/master"
+				},
+				"slaves": {
+					"$ref": "#/definitions/slaves"
 				}
-			  }
 			},
 			"required": [
-			  "name",
-			  "values"
+				"master",
+				"slaves"
 			]
-		  }
-	  },
-	  "signal_representations": {
-		"type": "array",
-		"items": {
-			"type": "object",
-			"properties": {
-			  "encoding": {
-				"type": "string"
-			  },
-			  "signals": {
-				"type": "array",
-				"items": {
-					"type": "string"
+		},
+		"signals": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/signal"
+			}
+		},
+		"frames": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/frame"
+			}
+		},
+		"event_triggered_frames": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/event_triggered_frame"
+			}
+		},
+		"node_attributes": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/node"
+			}
+		},
+		"schedule_tables": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"schedule": {
+						"type": "array",
+						"items": {
+							"$ref": "#/definitions/schedule_table_entry"
+						}
+					}
 				}
-			  }
-			},
-			"required": [
-			  "encoding",
-			  "signals"
-			]
-		  }
-	  }
+			}
+		},
+		"signal_encoding_types": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"values": {
+						"type": "array",
+						"items": {
+							"oneOf": [
+								{
+									"$ref": "#/definitions/logical_value_encoder"
+								},
+								{
+									"$ref": "#/definitions/physical_value_encoder"
+								}
+							]
+						}
+					}
+				},
+				"required": [
+					"name",
+					"values"
+				]
+			}
+		},
+		"signal_representations": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"encoding": {
+						"type": "string"
+					},
+					"signals": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				},
+				"required": [
+					"encoding",
+					"signals"
+				]
+			}
+		}
 	},
 	"required": [
-	  "header",
-	  "protocol_version",
-	  "language_version",
-	  "speed",
-	  "nodes",
-	  "signals",
-	  "frames",
-	  "schedule_tables"
+		"header",
+		"protocol_version",
+		"language_version",
+		"speed",
+		"nodes",
+		"signals",
+		"frames",
+		"schedule_tables"
 	]
-  }
+}

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -65,6 +65,176 @@
 			  "init_value",
 			  "publisher"
 			]
+		},
+		"frame": {
+			"type": "object",
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"frame_id": {
+					"type": "integer"
+				},
+				"publisher": {
+					"type": "string"
+				},
+				"length": {
+					"type": ["integer", "null"]
+				},
+				"signals": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"signal": {
+								"type": "string"
+							},
+							"offset": {
+								"type": "integer"
+							}
+						},
+						"required": [
+							"signal",
+							"offset"
+						]
+					}
+				}
+			},
+			"required": [
+				"name",
+				"frame_id",
+				"publisher",
+				"length",
+				"signals"
+			]
+		},
+		"event_triggered_frame": {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  }
+			},
+			"required": [
+			  "name"
+			]
+		},
+		"node": {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "lin_protocol": {
+				"type": "number"
+			  },
+			  "configured_nad": {
+				"type": "integer"
+			  },
+			  "initial_nad": {
+				"type": "integer"
+			  },
+			  "product_id": {
+				"type": "object",
+				"properties": {
+				  "supplier_id": {
+					"type": "integer"
+				  },
+				  "function_id": {
+					"type": "integer"
+				  },
+				  "variant": {
+					"type": "integer"
+				  }
+				},
+				"required": [
+				  "supplier_id",
+				  "function_id"
+				]
+			  },
+			  "response_error": {
+				"type": "string"
+			  },
+			  "fault_state_signals": {
+				"type": "array",
+				"items":{
+					"type": "string"
+				}
+			  },
+			  "P2_min": {
+				"type": "number"
+			  },
+			  "ST_min": {
+				"type": "number"
+			  },
+			  "N_As_timeout": {
+				"type": "number"
+			  },
+			  "N_Cr_timeout": {
+				"type": "number"
+			  },
+			  "configurable_frames": {
+				"type": ["array", "object"],
+				"items": {
+					"type": "string"
+				}
+			  }
+			},
+			"required": [
+			  "name",
+			  "lin_protocol",
+			  "configured_nad"
+			]
+		},
+		"logical_value_encoder": {
+			"type": "object",
+			"properties": {
+				"type": {
+				"type": "string"
+				},
+				"value": {
+				"type": "integer"
+				},
+				"text": {
+				"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"value",
+				"text"
+			]
+		},
+		"physical_value_encoder": {
+			"type": "object",
+			"properties": {
+				"type": {
+				"type": "string"
+				},
+				"min": {
+				"type": "number"
+				},
+				"max": {
+				"type": "number"
+				},
+				"scale": {
+				"type": "number"
+				},
+				"offset": {
+				"type": "number"
+				},
+				"unit": {
+				"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"min",
+				"max",
+				"scale",
+				"offset",
+				"unit"
+			]
 		}
 	},
 	"properties": {
@@ -107,1008 +277,25 @@
 	  },
 	  "frames": {
 		"type": "array",
-		"items": [
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "frame_id": {
-				"type": "integer"
-			  },
-			  "publisher": {
-				"type": "string"
-			  },
-			  "length": {
-				"type": "integer"
-			  },
-			  "signals": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "signal": {
-						"type": "string"
-					  },
-					  "offset": {
-						"type": "integer"
-					  }
-					},
-					"required": [
-					  "signal",
-					  "offset"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "frame_id",
-			  "publisher",
-			  "length",
-			  "signals"
-			]
-		  }
-		]
+		"items": {
+			"$ref": "#/definitions/frame"
+		}
 	  },
 	  "event_triggered_frames": {
 		"type": "array",
-		"items": [
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  }
-			},
-			"required": [
-			  "name"
-			]
-		  }
-		]
+		"items": {
+			"$ref": "#/definitions/event_triggered_frame"
+		}
 	  },
 	  "node_attributes": {
 		"type": "array",
-		"items": [
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "lin_protocol": {
-				"type": "number"
-			  },
-			  "configured_nad": {
-				"type": "integer"
-			  },
-			  "initial_nad": {
-				"type": "integer"
-			  },
-			  "product_id": {
-				"type": "object",
-				"properties": {
-				  "supplier_id": {
-					"type": "integer"
-				  },
-				  "function_id": {
-					"type": "integer"
-				  },
-				  "variant": {
-					"type": "integer"
-				  }
-				},
-				"required": [
-				  "supplier_id",
-				  "function_id",
-				  "variant"
-				]
-			  },
-			  "response_error": {
-				"type": "string"
-			  },
-			  "fault_state_signals": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "string"
-				  }
-				]
-			  },
-			  "P2_min": {
-				"type": "number"
-			  },
-			  "ST_min": {
-				"type": "number"
-			  },
-			  "N_As_timeout": {
-				"type": "number"
-			  },
-			  "N_Cr_timeout": {
-				"type": "number"
-			  },
-			  "configurable_frames": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "string"
-				  },
-				  {
-					"type": "string"
-				  },
-				  {
-					"type": "string"
-				  },
-				  {
-					"type": "string"
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "lin_protocol",
-			  "configured_nad",
-			  "initial_nad",
-			  "product_id",
-			  "response_error",
-			  "fault_state_signals",
-			  "P2_min",
-			  "ST_min",
-			  "N_As_timeout",
-			  "N_Cr_timeout",
-			  "configurable_frames"
-			]
-		  }
-		]
-	  },
-	  "schedule_tables": {
-		"type": "array",
-		"items": [
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "schedule": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "node": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "node"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "node": {
-							"type": "string"
-						  },
-						  "frame_index": {
-							"type": "integer"
-						  },
-						  "pids": {
-							"type": "array",
-							"items": {}
-						  }
-						},
-						"required": [
-						  "type",
-						  "node",
-						  "frame_index",
-						  "pids"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "node": {
-							"type": "string"
-						  },
-						  "frame_index": {
-							"type": "integer"
-						  },
-						  "pids": {
-							"type": "array",
-							"items": [
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  }
-							]
-						  }
-						},
-						"required": [
-						  "type",
-						  "node",
-						  "frame_index",
-						  "pids"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "nad": {
-							"type": "integer"
-						  },
-						  "id": {
-							"type": "integer"
-						  },
-						  "byte": {
-							"type": "integer"
-						  },
-						  "mask": {
-							"type": "integer"
-						  },
-						  "inv": {
-							"type": "integer"
-						  },
-						  "new_nad": {
-							"type": "integer"
-						  }
-						},
-						"required": [
-						  "type",
-						  "nad",
-						  "id",
-						  "byte",
-						  "mask",
-						  "inv",
-						  "new_nad"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "node": {
-							"type": "string"
-						  },
-						  "data": {
-							"type": "array",
-							"items": [
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  }
-							]
-						  }
-						},
-						"required": [
-						  "type",
-						  "node",
-						  "data"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "node": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "node"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "node": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "node",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "node": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "node",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "node": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "node",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "data": {
-							"type": "array",
-							"items": [
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  },
-							  {
-								"type": "integer"
-							  }
-							]
-						  }
-						},
-						"required": [
-						  "type",
-						  "data"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "schedule"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "schedule": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "schedule"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "schedule": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "schedule"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "schedule": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "schedule"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "schedule": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "command": {
-						"type": "object",
-						"properties": {
-						  "type": {
-							"type": "string"
-						  },
-						  "frame": {
-							"type": "string"
-						  }
-						},
-						"required": [
-						  "type",
-						  "frame"
-						]
-					  },
-					  "delay": {
-						"type": "number"
-					  }
-					},
-					"required": [
-					  "command",
-					  "delay"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "schedule"
-			]
-		  }
-		]
+		"items": {
+			"$ref": "#/definitions/node"
+		}
 	  },
 	  "signal_encoding_types": {
 		"type": "array",
-		"items": [
-		  {
+		"items": {
 			"type": "object",
 			"properties": {
 			  "name": {
@@ -1116,318 +303,12 @@
 			  },
 			  "values": {
 				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
+				"items": {
+					"oneOf": [
+						{"$ref": "#/definitions/logical_value_encoder"},
+						{"$ref": "#/definitions/physical_value_encoder"}
 					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "values"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "values": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "values"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "values": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "name",
-			  "values"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "name": {
-				"type": "string"
-			  },
-			  "values": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "min": {
-						"type": "number"
-					  },
-					  "max": {
-						"type": "number"
-					  },
-					  "scale": {
-						"type": "number"
-					  },
-					  "offset": {
-						"type": "number"
-					  },
-					  "unit": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "min",
-					  "max",
-					  "scale",
-					  "offset",
-					  "unit"
-					]
-				  },
-				  {
-					"type": "object",
-					"properties": {
-					  "type": {
-						"type": "string"
-					  },
-					  "value": {
-						"type": "integer"
-					  },
-					  "text": {
-						"type": "string"
-					  }
-					},
-					"required": [
-					  "type",
-					  "value",
-					  "text"
-					]
-				  }
-				]
+				}
 			  }
 			},
 			"required": [
@@ -1435,12 +316,10 @@
 			  "values"
 			]
 		  }
-		]
 	  },
 	  "signal_representations": {
 		"type": "array",
-		"items": [
-		  {
+		"items": {
 			"type": "object",
 			"properties": {
 			  "encoding": {
@@ -1448,77 +327,9 @@
 			  },
 			  "signals": {
 				"type": "array",
-				"items": [
-				  {
+				"items": {
 					"type": "string"
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "encoding",
-			  "signals"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "encoding": {
-				"type": "string"
-			  },
-			  "signals": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "string"
-				  },
-				  {
-					"type": "string"
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "encoding",
-			  "signals"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "encoding": {
-				"type": "string"
-			  },
-			  "signals": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "string"
-				  }
-				]
-			  }
-			},
-			"required": [
-			  "encoding",
-			  "signals"
-			]
-		  },
-		  {
-			"type": "object",
-			"properties": {
-			  "encoding": {
-				"type": "string"
-			  },
-			  "signals": {
-				"type": "array",
-				"items": [
-				  {
-					"type": "string"
-				  },
-				  {
-					"type": "string"
-				  }
-				]
+				}
 			  }
 			},
 			"required": [
@@ -1526,7 +337,6 @@
 			  "signals"
 			]
 		  }
-		]
 	  }
 	},
 	"required": [
@@ -1534,14 +344,9 @@
 	  "protocol_version",
 	  "language_version",
 	  "speed",
-	  "channel_name",
 	  "nodes",
 	  "signals",
 	  "frames",
-	  "event_triggered_frames",
-	  "node_attributes",
-	  "schedule_tables",
-	  "signal_encoding_types",
-	  "signal_representations"
+	  "schedule_tables"
 	]
   }

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -1,0 +1,1547 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "LDF",
+	"type": "object",
+	"definitions": {
+		"header": {
+			"type": "string",
+			"pattern": "lin_description_file"
+		},
+		"version" : {
+			"type": "number",
+			"minimum": 0.0,
+			"maximum": 2.2
+		},
+		"master": {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "timebase": {
+				"type": "number"
+			  },
+			  "jitter": {
+				"type": "number"
+			  }
+			},
+			"required": [
+			  "name",
+			  "timebase",
+			  "jitter"
+			]
+		},
+		"slaves": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"signal": {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "width": {
+				"type": "integer"
+			  },
+			  "init_value": {
+				"type": "integer"
+			  },
+			  "publisher": {
+				"type": "string"
+			  },
+			  "subscribers": {
+				"type": "array",
+				"items": {
+					"type": "string"
+				}
+			  }
+			},
+			"required": [
+			  "name",
+			  "width",
+			  "init_value",
+			  "publisher"
+			]
+		}
+	},
+	"properties": {
+	  "header": {
+		"$ref": "#/definitions/header"
+	  },
+	  "protocol_version": {
+		"$ref": "#/definitions/version",
+		"description": ""
+	  },
+	  "language_version": {
+		"$ref": "#/definitions/version"
+	  },
+	  "speed": {
+		"type": "integer"
+	  },
+	  "channel_name": {
+		"type": "string"
+	  },
+	  "nodes": {
+		"type": "object",
+		"properties": {
+		  "master": {
+			"$ref": "#/definitions/master"
+		  },
+		  "slaves": {
+			"$ref": "#/definitions/slaves"
+		  }
+		},
+		"required": [
+		  "master",
+		  "slaves"
+		]
+	  },
+	  "signals": {
+		"type": "array",
+		"items": {
+			"$ref": "#/definitions/signal"
+		}
+	  },
+	  "frames": {
+		"type": "array",
+		"items": [
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "frame_id": {
+				"type": "integer"
+			  },
+			  "publisher": {
+				"type": "string"
+			  },
+			  "length": {
+				"type": "integer"
+			  },
+			  "signals": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "signal": {
+						"type": "string"
+					  },
+					  "offset": {
+						"type": "integer"
+					  }
+					},
+					"required": [
+					  "signal",
+					  "offset"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "frame_id",
+			  "publisher",
+			  "length",
+			  "signals"
+			]
+		  }
+		]
+	  },
+	  "event_triggered_frames": {
+		"type": "array",
+		"items": [
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  }
+			},
+			"required": [
+			  "name"
+			]
+		  }
+		]
+	  },
+	  "node_attributes": {
+		"type": "array",
+		"items": [
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "lin_protocol": {
+				"type": "number"
+			  },
+			  "configured_nad": {
+				"type": "integer"
+			  },
+			  "initial_nad": {
+				"type": "integer"
+			  },
+			  "product_id": {
+				"type": "object",
+				"properties": {
+				  "supplier_id": {
+					"type": "integer"
+				  },
+				  "function_id": {
+					"type": "integer"
+				  },
+				  "variant": {
+					"type": "integer"
+				  }
+				},
+				"required": [
+				  "supplier_id",
+				  "function_id",
+				  "variant"
+				]
+			  },
+			  "response_error": {
+				"type": "string"
+			  },
+			  "fault_state_signals": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "string"
+				  }
+				]
+			  },
+			  "P2_min": {
+				"type": "number"
+			  },
+			  "ST_min": {
+				"type": "number"
+			  },
+			  "N_As_timeout": {
+				"type": "number"
+			  },
+			  "N_Cr_timeout": {
+				"type": "number"
+			  },
+			  "configurable_frames": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "string"
+				  },
+				  {
+					"type": "string"
+				  },
+				  {
+					"type": "string"
+				  },
+				  {
+					"type": "string"
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "lin_protocol",
+			  "configured_nad",
+			  "initial_nad",
+			  "product_id",
+			  "response_error",
+			  "fault_state_signals",
+			  "P2_min",
+			  "ST_min",
+			  "N_As_timeout",
+			  "N_Cr_timeout",
+			  "configurable_frames"
+			]
+		  }
+		]
+	  },
+	  "schedule_tables": {
+		"type": "array",
+		"items": [
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "schedule": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "node": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "node"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "node": {
+							"type": "string"
+						  },
+						  "frame_index": {
+							"type": "integer"
+						  },
+						  "pids": {
+							"type": "array",
+							"items": {}
+						  }
+						},
+						"required": [
+						  "type",
+						  "node",
+						  "frame_index",
+						  "pids"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "node": {
+							"type": "string"
+						  },
+						  "frame_index": {
+							"type": "integer"
+						  },
+						  "pids": {
+							"type": "array",
+							"items": [
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  }
+							]
+						  }
+						},
+						"required": [
+						  "type",
+						  "node",
+						  "frame_index",
+						  "pids"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "nad": {
+							"type": "integer"
+						  },
+						  "id": {
+							"type": "integer"
+						  },
+						  "byte": {
+							"type": "integer"
+						  },
+						  "mask": {
+							"type": "integer"
+						  },
+						  "inv": {
+							"type": "integer"
+						  },
+						  "new_nad": {
+							"type": "integer"
+						  }
+						},
+						"required": [
+						  "type",
+						  "nad",
+						  "id",
+						  "byte",
+						  "mask",
+						  "inv",
+						  "new_nad"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "node": {
+							"type": "string"
+						  },
+						  "data": {
+							"type": "array",
+							"items": [
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  }
+							]
+						  }
+						},
+						"required": [
+						  "type",
+						  "node",
+						  "data"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "node": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "node"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "node": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "node",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "node": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "node",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "node": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "node",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "data": {
+							"type": "array",
+							"items": [
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  },
+							  {
+								"type": "integer"
+							  }
+							]
+						  }
+						},
+						"required": [
+						  "type",
+						  "data"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "schedule"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "schedule": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "schedule"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "schedule": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "schedule"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "schedule": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "schedule"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "schedule": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "command": {
+						"type": "object",
+						"properties": {
+						  "type": {
+							"type": "string"
+						  },
+						  "frame": {
+							"type": "string"
+						  }
+						},
+						"required": [
+						  "type",
+						  "frame"
+						]
+					  },
+					  "delay": {
+						"type": "number"
+					  }
+					},
+					"required": [
+					  "command",
+					  "delay"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "schedule"
+			]
+		  }
+		]
+	  },
+	  "signal_encoding_types": {
+		"type": "array",
+		"items": [
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "values": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "values"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "values": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "values"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "values": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "values"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "name": {
+				"type": "string"
+			  },
+			  "values": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "min": {
+						"type": "number"
+					  },
+					  "max": {
+						"type": "number"
+					  },
+					  "scale": {
+						"type": "number"
+					  },
+					  "offset": {
+						"type": "number"
+					  },
+					  "unit": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "min",
+					  "max",
+					  "scale",
+					  "offset",
+					  "unit"
+					]
+				  },
+				  {
+					"type": "object",
+					"properties": {
+					  "type": {
+						"type": "string"
+					  },
+					  "value": {
+						"type": "integer"
+					  },
+					  "text": {
+						"type": "string"
+					  }
+					},
+					"required": [
+					  "type",
+					  "value",
+					  "text"
+					]
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "name",
+			  "values"
+			]
+		  }
+		]
+	  },
+	  "signal_representations": {
+		"type": "array",
+		"items": [
+		  {
+			"type": "object",
+			"properties": {
+			  "encoding": {
+				"type": "string"
+			  },
+			  "signals": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "string"
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "encoding",
+			  "signals"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "encoding": {
+				"type": "string"
+			  },
+			  "signals": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "string"
+				  },
+				  {
+					"type": "string"
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "encoding",
+			  "signals"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "encoding": {
+				"type": "string"
+			  },
+			  "signals": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "string"
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "encoding",
+			  "signals"
+			]
+		  },
+		  {
+			"type": "object",
+			"properties": {
+			  "encoding": {
+				"type": "string"
+			  },
+			  "signals": {
+				"type": "array",
+				"items": [
+				  {
+					"type": "string"
+				  },
+				  {
+					"type": "string"
+				  }
+				]
+			  }
+			},
+			"required": [
+			  "encoding",
+			  "signals"
+			]
+		  }
+		]
+	  }
+	},
+	"required": [
+	  "header",
+	  "protocol_version",
+	  "language_version",
+	  "speed",
+	  "channel_name",
+	  "nodes",
+	  "signals",
+	  "frames",
+	  "event_triggered_frames",
+	  "node_attributes",
+	  "schedule_tables",
+	  "signal_encoding_types",
+	  "signal_representations"
+	]
+  }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,24 @@
+import jsonschema
+import ldfparser
+import os
+import glob
+import json
+import pytest
+
+from jsonschema import validate
+
+
+ldf_directory = os.path.join(os.path.dirname(__file__), 'ldf')
+ldf_files = glob.glob(ldf_directory + '/*.ldf')
+
+json_schema = json.load(open('schemas/ldf.json',))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+	('ldf_path'),
+	ldf_files
+)
+def test_json_schema(ldf_path):
+	data = ldfparser.parseLDFtoDict(ldf_path)
+	validate(data, schema=json_schema)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,3 @@
-import jsonschema
 import ldfparser
 import os
 import glob


### PR DESCRIPTION
## Brief

Currently the parsing mechanism transforms the LDF into a dictionary (JSON) however the format of this dictionary is not locked, so users cannot rely on a stable schema. The format is somewhat locked, we have snapshot tests for the outputs so we know if a PR breaks the format but the schema itself may not be evident to developers using the dictionary feature or to other tools interfacing with the output.

## Evidence

+ Functionality will be unit tested using `jsonschema` library
