### PR TITLE
Fixes missing encoder scenario

### DIFF
--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -92,7 +92,7 @@ class LinFrame:
 		"""
 		converted = {}
 		for value in data.items():
-			if converters[value[0]] is None:
+			if value[0] not in converters.keys():
 				raise ValueError('No encoder found for ' + value[0])
 			converted[value[0]] = converters[value[0]].encode(value[1], self._get_signal(value[0]))
 		return self.raw(converted)
@@ -123,7 +123,7 @@ class LinFrame:
 		tmp = self.parse_raw(data)
 		output = {}
 		for value in tmp.items():
-			if converters[value[0]] is None:
+			if value[0] not in converters.keys():
 				raise ValueError('No decoder found for ' + value[0])
 			output[value[0]] = converters[value[0]].decode(value[1], self._get_signal(value[0]))
 		return output


### PR DESCRIPTION
## Brief

When encoders are missing in frame conversion methods a `KeyError` is thrown instead of the expected `ValueError`.

## Evidence

+ Tests have been added to cover the missing encoder scenarios for both encoding and decoding frames
+ Furthermore a test for frame parsing has been added
