### PR TITLE
Adds Python 3.10 to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-beta.1']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Brief

+ Currently only Python version 3.6 to 3.9 are tested, 3.10 is scheduled to be stable in Q4 2021.
+ From 0.5.0 there were experiments with doing pre-release or development builds and publishing them to the test package index, this plan has since been abandoned