### PR TITLE
Fixes missing encoding types `ascii_value` and `bcd_value`.

### DIFF
--- a/ldfparser/ldf.lark
+++ b/ldfparser/ldf.lark
@@ -92,7 +92,7 @@ signal_group: ldf_identifier ":" ldf_integer "{" (ldf_identifier "," ldf_integer
 
 // LIN 2.1 Specification, section 9.2.6.1
 signal_encoding_types: "Signal_encoding_types" "{" (signal_encoding_type+) "}" 
-signal_encoding_type: ldf_identifier "{" (signal_encoding_logical_value | signal_encoding_physical_value)+ "}"
+signal_encoding_type: ldf_identifier "{" (signal_encoding_logical_value | signal_encoding_physical_value | signal_encoding_bcd_value | signal_encoding_ascii_value)+ "}"
 signal_encoding_logical_value: "logical_value" "," ldf_integer ("," signal_encoding_text_value)? ";"
 signal_encoding_physical_value: "physical_value" "," ldf_integer "," ldf_integer "," ldf_float "," ldf_float ("," signal_encoding_text_value)? ";"
 signal_encoding_bcd_value: "bcd_value" ";"

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -433,7 +433,29 @@
 				"offset",
 				"unit"
 			]
-		}
+		},
+        "bcd_value_encoder": {
+            "type":"object",
+            "properties": {
+                "type": {
+                    "enum": ["bcd"]
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "ascii_value_encoder": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "enum": ["ascii"]
+                }
+            },
+            "required": [
+                "type"
+            ]
+        }
 	},
 	"properties": {
 		"header": {
@@ -525,6 +547,12 @@
 								},
 								{
 									"$ref": "#/definitions/physical_value_encoder"
+								},
+								{
+									"$ref": "#/definitions/bcd_value_encoder"
+								},
+								{
+									"$ref": "#/definitions/ascii_value_encoder"
 								}
 							]
 						}

--- a/tests/ldf/lin_encoders.ldf
+++ b/tests/ldf/lin_encoders.ldf
@@ -1,0 +1,105 @@
+/*******************************************************/
+/* This is a synthetic example LDF from the LIN 2.2A   */
+/* specification that combines all examples of signal  */
+/* encodings.                                          */
+/*******************************************************/
+
+// Source: https://lin-cia.org/fileadmin/microsites/lin-cia.org/resources/documents/LIN_2.2A.pdf
+
+LIN_description_file;
+LIN_protocol_version = "2.1";
+LIN_language_version = "2.1";
+LIN_speed = 19.2 kbps;
+
+Nodes {
+  Master: main_node, 5 ms, 1 ms ;
+  Slaves: remote_node;
+}
+
+Signals {
+    bcd_signal: 16, 0, remote_node, main_node ;
+  //ascii_signal: 48, {0,0,0,0,0,0} , remote_node, main_node ;
+    ascii_signal: 16, 0, remote_node, main_node ;
+}
+
+Frames {
+  dummy_frame: 0x25, remote_node, 8 {
+    bcd_signal, 0;
+    ascii_signal, 16;
+  }
+}
+
+Node_attributes {
+  remote_node {
+    LIN_protocol = "2.1" ;
+    configured_NAD = 0x20 ;
+    product_id = 0x5, 0xA5A5, 0 ;
+    response_error = RE;
+    P2_min = 50 ms ;
+    ST_min = 0 ms ;
+    N_As_timeout = 1000 ms ;
+    N_Cr_timeout = 1000 ms ;
+    configurable_frames {
+      dummy_frame ;
+    }
+  }
+}
+
+Schedule_tables {
+ MRF_schedule {
+		MasterReq delay 10 ms;
+	}
+	SRF_schedule {
+		SlaveResp delay 10 ms;
+	}
+    Normal_Schedule {
+    dummy_frame delay 15 ms ;
+  }
+}
+
+Signal_encoding_types {
+  power_state {
+    logical_value, 0, "off";
+    logical_value, 1, "on";
+  }
+  V_battery {
+    logical_value, 0, "under voltage";
+    physical_value, 1, 63, 0.0625, 7.0, "Volt";
+    physical_value, 64, 191, 0.0104, 11.0, "Volt";
+    physical_value, 192, 253, 0.0625, 13.0, "Volt";
+    logical_value, 254, "over voltage";
+    logical_value, 255, "invalid";
+  }
+  Dig2Bit {
+    logical_value, 0, "off";
+    logical_value, 1, "on";
+    logical_value, 2, "error";
+    logical_value, 3, "void";
+  }
+  ErrorEncoding {
+    logical_value, 0, "OK";
+    logical_value, 1, "error";
+  }
+  FaultStateEncoding {
+    logical_value, 0, "No test result";
+    logical_value, 1, "failed";
+    logical_value, 2, "passed";
+    logical_value, 3, "not used";
+  }
+  LightEncoding {
+    logical_value, 0, "Off";
+    physical_value, 1, 254, 1, 100, "lux";
+    logical_value, 255, "error";
+  }
+  AsciiEncoding {
+    ascii_value;
+  }
+  BCDEncoding {
+    bcd_value;
+  }
+}
+
+Signal_representation {
+  BCDEncoding: bcd_signal;
+  AsciiEncoding: ascii_signal;
+}

--- a/tests/ldf/lin_encoders.ldf
+++ b/tests/ldf/lin_encoders.ldf
@@ -18,7 +18,6 @@ Nodes {
 
 Signals {
     bcd_signal: 16, 0, remote_node, main_node ;
-  //ascii_signal: 48, {0,0,0,0,0,0} , remote_node, main_node ;
     ascii_signal: 16, 0, remote_node, main_node ;
 }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -84,6 +84,7 @@ def test_load_valid_lin22():
 	assert converter.name == 'Dig2Bit'
 	assert isinstance(converter._converters[0], LogicalValue)
 
+
 @pytest.mark.unit
 def test_no_signal_subscribers():
 	path = os.path.join(os.path.dirname(__file__), "ldf", "no_signal_subscribers.ldf")
@@ -95,6 +96,7 @@ def test_no_signal_subscribers():
 
 	assert ldf.signal('DummySignal_0') is not None
 	assert ldf.frame('DummyFrame') is not None
+
 
 @pytest.mark.unit
 def test_load_valid_lin_encoders():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,4 @@
-from ldfparser.encoding import LogicalValue
+from ldfparser.encoding import LogicalValue, BCDValue, ASCIIValue
 import os
 import pytest
 import ldfparser
@@ -84,7 +84,6 @@ def test_load_valid_lin22():
 	assert converter.name == 'Dig2Bit'
 	assert isinstance(converter._converters[0], LogicalValue)
 
-
 @pytest.mark.unit
 def test_no_signal_subscribers():
 	path = os.path.join(os.path.dirname(__file__), "ldf", "no_signal_subscribers.ldf")
@@ -96,3 +95,42 @@ def test_no_signal_subscribers():
 
 	assert ldf.signal('DummySignal_0') is not None
 	assert ldf.frame('DummyFrame') is not None
+
+@pytest.mark.unit
+def test_load_valid_lin_encoders():
+	path = os.path.join(os.path.dirname(__file__), "ldf", "lin_encoders.ldf")
+	ldf = ldfparser.parseLDF(path)
+
+	assert ldf.protocol_version == 2.1
+	assert ldf.language_version == 2.1
+	assert ldf.baudrate == 19200
+
+	bcd_signal = ldf.signal('bcd_signal')
+	assert bcd_signal is not None
+	assert bcd_signal.publisher.name == 'remote_node'
+	assert len(bcd_signal.subscribers) == 1
+	assert bcd_signal in ldf.slave('remote_node').publishes
+
+	ascii_signal = ldf.signal('ascii_signal')
+	assert ascii_signal is not None
+	assert ascii_signal.publisher.name == 'remote_node'
+	assert len(ascii_signal.subscribers) == 1
+	assert ascii_signal in ldf.slave('remote_node').publishes
+
+	assert ldf.frame('dummy_frame') is not None
+	assert ldf.frame(0x25) is not None
+
+	remote_node = ldf.slave('remote_node')
+	assert remote_node is not None
+	assert remote_node.product_id.supplier_id == 0x5
+	assert remote_node.product_id.function_id == 0xA5A5
+
+	converter = ldf.converters['bcd_signal']
+	assert converter.name == 'BCDEncoding'
+	assert len(converter._converters) == 1
+	assert isinstance(converter._converters[0], BCDValue)
+
+	converter = ldf.converters['ascii_signal']
+	assert converter.name == 'AsciiEncoding'
+	assert len(converter._converters) == 1
+	assert isinstance(converter._converters[0], ASCIIValue)


### PR DESCRIPTION
## Brief
LIN 2.1 allows for BCD and ASCII encodings to be specified. Seems like the types were defined but not included in `signal_encoding_type`.

## Fixes
* adds the relevant types to `signal_encoding_type` definition.

## Evidence
The LIN spec document doesn't include BCD or ASCII examples in the relevant sections (9.2.6.1 or 9.4.1) so I've added a few to [an LDF with all the existing examples](https://github.com/c4deszes/ldfparser/files/6650197/test_ldf.txt) (extension is .txt because of GitHub extension filter). This change doesn't interfere with any of the LDF testing files.



Since the types are already defined in the lark file & python code this seems like a simple oversight.
