### PR TITLE
Fixes token parsing for byte array initial values.

### DIFF
--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -303,10 +303,10 @@ class LDFTransformer(Transformer):
 		return tree[0]
 
 	def signal_default_value_single(self, tree):
-		return int(tree[0])
+		return int(tree[0], 0)
 
 	def signal_default_value_array(self, tree):
-		return tree[0]
+		return [int(v, 0) for v in tree]
 
 	def diagnostic_signals(self, tree):
 		return ("diagnostic_signals", [])

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -47,7 +47,19 @@
 					"type": "integer"
 				},
 				"init_value": {
-					"type": "integer"
+                    "oneOf":[
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type":"integer"
+                            },
+                            "minItems": 1,
+                            "maxItems": 8
+                        }
+                    ]
 				},
 				"publisher": {
 					"type": "string"

--- a/tests/ldf/lin_encoders.ldf
+++ b/tests/ldf/lin_encoders.ldf
@@ -17,14 +17,20 @@ Nodes {
 }
 
 Signals {
-    bcd_signal: 16, 0, remote_node, main_node ;
-    ascii_signal: 16, 0, remote_node, main_node ;
+    bcd_signal: 16, 0x42, remote_node, main_node ;
+    ascii_signal: 48, {72, 0x65, 0x6C, 0x6C, 111, 33}, remote_node, main_node ;
+    byte_array_signal_0: 32, {0x11, 0x22, 0x33, 0x44}, remote_node, main_node ;
+    byte_array_signal_1: 32, {0x55, 0x66, 0x77, 0x88}, remote_node, main_node ;
 }
 
 Frames {
-  dummy_frame: 0x25, remote_node, 8 {
+  dummy_frame_0: 0x25, remote_node, 8 {
     bcd_signal, 0;
     ascii_signal, 16;
+  }
+  dummy_frame_1: 0x26, remote_node, 8 {
+    byte_array_signal_0, 0;
+    byte_array_signal_1, 32;
   }
 }
 
@@ -39,21 +45,23 @@ Node_attributes {
     N_As_timeout = 1000 ms ;
     N_Cr_timeout = 1000 ms ;
     configurable_frames {
-      dummy_frame ;
+      dummy_frame_0;
+      dummy_frame_1;
     }
   }
 }
 
 Schedule_tables {
- MRF_schedule {
-		MasterReq delay 10 ms;
+    MRF_schedule {
+        MasterReq delay 10 ms;
 	}
 	SRF_schedule {
 		SlaveResp delay 10 ms;
 	}
     Normal_Schedule {
-    dummy_frame delay 15 ms ;
-  }
+        dummy_frame_0 delay 15 ms ;
+        dummy_frame_1 delay 15 ms ;
+    }
 }
 
 Signal_encoding_types {
@@ -96,9 +104,21 @@ Signal_encoding_types {
   BCDEncoding {
     bcd_value;
   }
+  LargePhysicalEncoding {
+      physical_value, 0, 0xFFFFFFFF, 1, 0, "count";
+  }
+  LargeLogicalEncoding {
+      logical_value, 0x88776655, "condition_default";
+      logical_value, 0x00000000, "condition_0";
+      logical_value, 0xFF00FF00, "condition_1";
+      logical_value, 0x00FFFF00, "condition_2";
+      logical_value, 0xFFFFFFFF, "condition_3";
+  }
 }
 
 Signal_representation {
   BCDEncoding: bcd_signal;
   AsciiEncoding: ascii_signal;
+  LargePhysicalEncoding: byte_array_signal_0;
+  LargeLogicalEncoding: byte_array_signal_1;
 }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,4 @@
-from ldfparser.encoding import LogicalValue, BCDValue, ASCIIValue
+from ldfparser.encoding import PhysicalValue, LogicalValue, BCDValue, ASCIIValue
 import os
 import pytest
 import ldfparser
@@ -119,8 +119,27 @@ def test_load_valid_lin_encoders():
 	assert len(ascii_signal.subscribers) == 1
 	assert ascii_signal in ldf.slave('remote_node').publishes
 
-	assert ldf.frame('dummy_frame') is not None
+	byte_array_signal_0 = ldf.signal('byte_array_signal_0')
+	assert byte_array_signal_0 is not None
+	assert byte_array_signal_0.publisher.name == 'remote_node'
+	assert len(byte_array_signal_0.subscribers) == 1
+	assert byte_array_signal_0 in ldf.slave('remote_node').publishes
+	assert byte_array_signal_0.is_array()
+	assert byte_array_signal_0.init_value == [17, 34, 51, 68]
+
+	byte_array_signal_1 = ldf.signal('byte_array_signal_1')
+	assert byte_array_signal_1 is not None
+	assert byte_array_signal_1.publisher.name == 'remote_node'
+	assert len(byte_array_signal_1.subscribers) == 1
+	assert byte_array_signal_1 in ldf.slave('remote_node').publishes
+	assert byte_array_signal_1.is_array()
+	assert byte_array_signal_1.init_value == [85, 102, 119, 136]
+
+	assert ldf.frame('dummy_frame_0') is not None
 	assert ldf.frame(0x25) is not None
+
+	assert ldf.frame('dummy_frame_1') is not None
+	assert ldf.frame(0x26) is not None
 
 	remote_node = ldf.slave('remote_node')
 	assert remote_node is not None
@@ -136,3 +155,16 @@ def test_load_valid_lin_encoders():
 	assert converter.name == 'AsciiEncoding'
 	assert len(converter._converters) == 1
 	assert isinstance(converter._converters[0], ASCIIValue)
+
+	converter = ldf.converters['byte_array_signal_0']
+	assert converter.name == 'LargePhysicalEncoding'
+	assert len(converter._converters) == 1
+	assert isinstance(converter._converters[0], PhysicalValue)
+
+	converter = ldf.converters['byte_array_signal_1']
+	assert converter.name == 'LargeLogicalEncoding'
+	assert len(converter._converters) == 5
+	logical_values = [0x88776655, 0x00000000, 0xFF00FF00, 0x00FFFF00, 0xFFFFFFFF]
+	for c, value in zip(converter._converters, logical_values):
+		assert isinstance(c, LogicalValue)
+		assert c.phy_value == value


### PR DESCRIPTION
## Brief

Allows for byte array initialization in LDF signal  definition block. Previously byte array initialization only picked up the first byte and `LinSignal.is_array()` always returned false. Additionally, the JSON schema for signals would throw validation errors for byte array initialization.

## Fixes
The `signal.init_value` schema is extended to allow for array of integers. The tree transform handler for byte array now correctly returns an array of values.

## Evidence

* Passes all test coverage.
* Only affects byte array initial value parsing. All handling of array  values are unchanged.
* Added test cases to existing LDF files.
