### PR TITLE
Fixes subscribed_to attribute on LinSlave objects

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ASCII and BCD encoding types missing from the syntax ( #56 )
+- Fixed `subscribed_to` variable on `LinSlave` containing the wrong objects ( #59 )
+
 ## [0.8.0] - 2021-06-01
 
 ## Added

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -179,7 +179,7 @@ def _link_ldf_signals(json: dict, ldf: LDF):
 				slave = ldf.slave(subscriber)
 				if slave is None:
 					raise ValueError(f"Signal {signal_obj.name} references non existent node {subscriber}")
-				slave.subscribes_to.append(signal)
+				slave.subscribes_to.append(signal_obj)
 				signal_obj.subscribers.append(slave)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+from ldfparser.lin import LinFrame, LinSignal
 from ldfparser.encoding import LogicalValue, BCDValue, ASCIIValue
 import os
 import pytest
@@ -77,6 +78,9 @@ def test_load_valid_lin22():
 
 	LSM = ldf.slave('LSM')
 	assert LSM is not None
+	assert isinstance(LSM.subscribes_to[0], LinSignal)
+	assert isinstance(LSM.publishes[0], LinSignal)
+	assert isinstance(LSM.publishes_frames[0], LinFrame)
 	assert LSM.product_id.supplier_id == 0x4A4F
 	assert LSM.product_id.function_id == 0x4841
 


### PR DESCRIPTION
## Brief

The LIN signal dictionary is being appended to the subscribed to list of `LinSlave`, instead of a `LinSignal` object.

## Fixes

Fixes #58 

## Evidence

+ *Test case pending*
