### PR TITLE
Syntax now allows whitespace in master definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed ASCII and BCD encoding types missing from the syntax ( #56 )
 - Fixed `subscribed_to` variable on `LinSlave` containing the wrong objects ( #59 )
+- Fixed whitespace not being allowed in the `Nodes` section before the colons ( #61 )
 
 ## [0.8.0] - 2021-06-01
 

--- a/ldfparser/ldf.lark
+++ b/ldfparser/ldf.lark
@@ -15,8 +15,8 @@ header_channel: "Channel_name" "=" "\"" ldf_identifier "\"" ";"
 
 // LIN 2.1 Specification, section 9.2.2
 nodes: "Nodes" "{" nodes_master nodes_slaves "}"
-nodes_master: "Master:" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ";"
-nodes_slaves: "Slaves:" ldf_identifier ("," ldf_identifier)* ";"
+nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ";"
+nodes_slaves: "Slaves" ":" ldf_identifier ("," ldf_identifier)* ";"
 
 // LIN 2.1 Specification, section 9.2.2.3
 node_compositions: "composite" "{" (node_compositions_configuration+) "}"

--- a/tests/ldf/lin13.ldf
+++ b/tests/ldf/lin13.ldf
@@ -7,8 +7,8 @@ LIN_language_version = "1.3";
 LIN_speed = 19.2 kbps;
 
 Nodes {
-	Master:CEM,5 ms, 0.1 ms;
-	Slaves:LSM,CPM;
+	Master : CEM,5 ms, 0.1 ms;
+	Slaves : LSM,CPM;
 }
 
 Signals {


### PR DESCRIPTION
## Brief

Whitespaces are not allowed in the Nodes section of the LDF in the Master and Slave definitions before the colon.

The following is not allowed `Master : CEM, 5 ms, 0.1 ms;` while `Master: CEM, 5 ms, 0.1 ms;` does work.

## Fixes

The `:` token has been separated from the keyword tokens. No other cases of merged tokens was noticed. 

Fixes #60 

## Evidence

The version 1.3 LDF has been updated to contain whitespace in the node definition section.
