### PR TITLE
Fixes parsing initial values of array signals

### DIFF
--- a/ldfparser/ldf.lark
+++ b/ldfparser/ldf.lark
@@ -27,8 +27,8 @@ node_compositions_composite: ldf_identifier "{" ldf_identifier ("," ldf_identifi
 signals: "Signals" "{" (signal_definition)+ "}"
 signal_definition: ldf_identifier ":" ldf_integer "," signal_default_value "," ldf_identifier ("," ldf_identifier)* ";"
 signal_default_value: signal_default_value_array | signal_default_value_single
-signal_default_value_single: C_INT
-signal_default_value_array: "{" C_INT ("," C_INT)* "}"
+signal_default_value_single: ldf_integer
+signal_default_value_array: "{" ldf_integer ("," ldf_integer)* "}"
 
 // LIN 2.1 Specification, section 9.2.3.2
 diagnostic_signals: "Diagnostic_signals" "{" (ANY_SEMICOLON_TERMINATED_LINE)* "}"

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -240,7 +240,8 @@ class LDFTransformer(Transformer):
 		try:
 			return float(i)
 		except ValueError:
-			return self.parse_int(i)
+			# TODO: dead code
+			return self.parse_integer(i)
 
 	def ldf_identifier(self, tree):
 		return tree[0][0:]
@@ -303,10 +304,10 @@ class LDFTransformer(Transformer):
 		return tree[0]
 
 	def signal_default_value_single(self, tree):
-		return int(tree[0])
+		return tree[0]
 
 	def signal_default_value_array(self, tree):
-		return tree[0]
+		return tree[0:]
 
 	def diagnostic_signals(self, tree):
 		return ("diagnostic_signals", [])

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -47,7 +47,19 @@
 					"type": "integer"
 				},
 				"init_value": {
-					"type": "integer"
+					"oneOf":[
+						{
+							"type": "integer"
+						},
+						{
+							"type": "array",
+							"items": {
+								"type":"integer"
+							},
+							"minItems": 1,
+							"maxItems": 8
+						}
+					]
 				},
 				"publisher": {
 					"type": "string"

--- a/tests/ldf/lin_encoders.ldf
+++ b/tests/ldf/lin_encoders.ldf
@@ -17,8 +17,8 @@ Nodes {
 }
 
 Signals {
-    bcd_signal: 16, 0, remote_node, main_node ;
-    ascii_signal: 16, 0, remote_node, main_node ;
+    bcd_signal: 16, {0x32, 32}, remote_node, main_node ;
+    ascii_signal: 16, {16, 0x16}, remote_node, main_node ;
 }
 
 Frames {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -116,12 +116,14 @@ def test_load_valid_lin_encoders():
 	assert bcd_signal.publisher.name == 'remote_node'
 	assert len(bcd_signal.subscribers) == 1
 	assert bcd_signal in ldf.slave('remote_node').publishes
+	assert bcd_signal.init_value == [0x32, 32]
 
 	ascii_signal = ldf.signal('ascii_signal')
 	assert ascii_signal is not None
 	assert ascii_signal.publisher.name == 'remote_node'
 	assert len(ascii_signal.subscribers) == 1
 	assert ascii_signal in ldf.slave('remote_node').publishes
+	assert ascii_signal.init_value == [16, 0x16]
 
 	assert ldf.frame('dummy_frame') is not None
 	assert ldf.frame(0x25) is not None


### PR DESCRIPTION
## Brief

The current lark file and parser doesn't read the correct initial value of an array type signal. The JSON schema part for array signal init values is also missing.

This is reopening/reworking #57 but without fixing issues in the encoding and other parts.

## Fixes

Init values should be read correctly, including hexadecimal values

## Evidence

Encoding test has been extended to check the initial value of the array signals.