### PR TITLE
Allows scientific notation to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2021-11-02
+
+### Added
+
+- Scientific notation is now allowed when providing floating point values
+
 ## [0.11.0] - 2021-10-17
 
 ### Added

--- a/ldfparser/lark/ldf.lark
+++ b/ldfparser/lark/ldf.lark
@@ -105,7 +105,7 @@ signal_representations: "Signal_representation" "{" (signal_representation_node+
 signal_representation_node: ldf_identifier ":" ldf_identifier ("," ldf_identifier)* ";"
 
 C_INT: ("0x"HEXDIGIT+) | ("-"? INT) 
-C_FLOAT: "-"? INT ("." INT)?
+C_FLOAT: ("-"? INT ("." INT)?) ("e" ("+" | "-")? INT)?
 C_VERSION: INT "." INT
 
 ANY_SEMICOLON_TERMINATED_LINE: /.*;/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.11.0
+version = 0.11.1


### PR DESCRIPTION
## Brief

The parser currently expects floating numbers in `[0-9]+(\.[0-9]+)?` format, scientific notation however allows the usage of exponentials (e.g.: `1.2345e-05`).

The LIN standard doesn't mention scientific notation and for the real number definition it specifies that it's a number with a decimal point. The addition of this shouldn't cause any problems.

### Checklist

- [x] Check test result and code coverage
- [ ] Update documentation
- [x] Update changelog
- [x] Update version number

## Solves

+ Resolves #74

## Evidence

+ The scientific notation's "e" suffix is optional, LDFs only using standard notation will work the same as before.
