### PR TITLE
Adds schedule table support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Schedule tables are now parsed into Python objects
 
+### Fixed
+
+- Added missing `UnassignFrameId` command to JSON schema
+
 ## [0.12.0] - 2021-11-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Schedule tables are now parsed into Python objects
+
 ## [0.12.0] - 2021-11-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.13.0]
+## [0.13.0] - 2022-02-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0]
+
 ### Added
 
 - Schedule tables are now parsed into Python objects
 
+### Changed
+
+- The delay of schedule entries in the dictionary now have a floating point type and their unit
+has been normalized to seconds
+
 ### Fixed
 
 - Added missing `UnassignFrameId` command to JSON schema
+
+### Migration guide for 0.13.0
+
+- Any reference to `ldf['schedule_tables'][id]['schedule'][entry]['delay']` that assumes that
+milliseconds are used as the unit has to be updated to either multiply the current value by `1000`
+or somehow change the assumption about the unit to seconds.
+All numeric values that have an associated unit have their SI prefix removed during parsing, for
+example `kbps` is converted into `bps`. The schedule entry delay was one case where it wasn't
+handled accordingly.
 
 ## [0.12.0] - 2021-11-21
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@
 
 ---
 
-## Disclaimer
+## Disclaimers
+
+The library is still in a pre-release state, therefore features may break between minor versions.
+For this reason it's recommended that productive environments pin to the exact version of the
+library and do an integration test or review when updating the version. Breaking changes and how to
+migrate to the new version will be documented in the
+[changelog](https://github.com/c4deszes/ldfparser/blob/master/CHANGELOG.md) and on the
+[Github releases page](https://github.com/c4deszes/ldfparser/releases).
 
 The tool has been written according the LIN standards 1.3, 2.0, 2.1 and 2.2A, but due to errors in
 the documentation there's no guarantee that the library will be able to parse your LDF. In such
@@ -22,7 +29,7 @@ cases if possible first verify the LDF with a commercial tool such as Vector LDF
 tool that was used to create the LDF.  If the LDF seems to be correct then open a new issue.
 I also recommend trying the LDF to JSON conversion mechanism, see if that succeeds.
 
-Also the LIN standard is now known as [ISO 17987](https://www.iso.org/standard/61222.html) which
+The LIN standard is now known as [ISO 17987](https://www.iso.org/standard/61222.html) which
 clears up some of the confusing parts in the 2.2A specification. Since this new standard is not
 freely available **this library won't support the modifications present in ISO 17987**. I don't
 think it's going to a huge problem because the LIN 2.2A released in 2010 has overall better adoption.
@@ -63,11 +70,11 @@ print(binascii.hexlify(message))
 
 # Decode message into dictionary of signal names and values
 received = bytearray([0x7B, 0x00])
-print(frame.decode(received, ldf.converters))
+print(frame.decode(received))
 >>> {"Signal_1": 123, "Signal_2": 0}
 
 # Encode signal values through converters
-message = frame.encode({"MotorRPM": 100, "FanState": "ON"}, ldf.converters)
+message = frame.encode({"MotorRPM": 100, "FanState": "ON"})
 print(binascii.hexlify(message))
 >>> 0xFE01
 ```
@@ -94,15 +101,23 @@ Documentation is published to [Github Pages](https://c4deszes.github.io/ldfparse
 
 + Retrieve Node attributes
 
++ Retrieve schedule table information
+
 + Command Line Interface
 
 + Capturing comments
 
-### Currently not supported
++ Encode and decode standard diagnostic frames
 
-+ Scheduling table
+### Known issues / missing features
 
-+ Diagnostics
++ Certain parsing related errors are unintuitive
+
++ Checksum calculation for frames
+
++ Saving LDF objects as an `.ldf` file
+
++ Token information is not preserved
 
 ---
 
@@ -110,7 +125,7 @@ Documentation is published to [Github Pages](https://c4deszes.github.io/ldfparse
 
 Install the requirements via `pip install -r requirements.txt`
 
-Install the library locally by running `python setup.py install`
+Install the library locally by running `pip install -e .`
 
 [Pytest](https://pytest.org/) is used for testing, to execute all tests run `pytest -m 'not snapshot'`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,10 @@ production use cases you pin the version to a minor release in your requirements
 
 [Using the command line interface](commandline.md)
 
+[Using diagnostic frames](diagnostics.md)
+
+[Accessing schedule tables](schedules.md)
+
 ## License
 
 Distributed under the terms of

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: LDF Parser - Schedules
+---
+
+## Accessing schedules
+
+### Retrieving schedule information
+
+After parsing the LDF into objects the schedule tables defined in the LDF will
+be accessible.
+
+```python
+ldf = parse_ldf('network.ldf')
+
+configuration_schedule = ldf.get_schedule('Configuration_Schedule')
+print(configuration_schedule.name)
+>>> 'Configuration_Schedule'
+for entry in configuration_schedule.schedule:
+    print(f"{type(entry).__name__} - {entry.delay * 1000} ms")
+>>> 'AssignNadEntry - 15 ms'
+>>> 'AssignFrameIdRangeEntry - 15 ms'
+>>> 'AssignFrameIdEntry - 15 ms'
+>>> 'AssignFrameIdEntry - 15 ms'
+>>> 'AssignFrameIdEntry - 15 ms'
+```
+
+The objects referenced in the table entries are also linked.
+
+```python
+print(configuration_schedule.schedule[0].node.name)
+>>> 'LSM'
+```

--- a/ldfparser/diagnostics.py
+++ b/ldfparser/diagnostics.py
@@ -1,6 +1,6 @@
 from typing import Iterable, Dict
 
-from ldfparser.frame import LinUnconditionalFrame
+from .frame import LinUnconditionalFrame
 
 # LIN Diagnostic Frame IDs
 LIN_MASTER_REQUEST_FRAME_ID = 0x3C

--- a/ldfparser/frame.py
+++ b/ldfparser/frame.py
@@ -2,12 +2,14 @@
 LIN Frame utilities
 """
 import warnings
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, TYPE_CHECKING
 
 import bitstruct
 
-from .signal import LinSignal
-from .encoding import LinSignalEncodingType
+if TYPE_CHECKING:
+    from .signal import LinSignal
+    from .encoding import LinSignalEncodingType
+    from .schedule import ScheduleTable
 
 class LinFrame():
     # pylint: disable=too-few-public-methods
@@ -42,7 +44,7 @@ class LinUnconditionalFrame(LinFrame):
     :type signals: Dict[int, LinSignal]
     """
 
-    def __init__(self, frame_id: int, name: str, length: int, signals: Dict[int, LinSignal]):
+    def __init__(self, frame_id: int, name: str, length: int, signals: Dict[int, 'LinSignal']):
         super().__init__(frame_id, name)
         self.publisher = None
         self.length = length
@@ -52,7 +54,7 @@ class LinUnconditionalFrame(LinFrame):
     @staticmethod
     def _frame_pattern(
             frame_size: int,
-            signals: List[Tuple[int, LinSignal]]) -> bitstruct.CompiledFormat:
+            signals: List[Tuple[int, 'LinSignal']]) -> bitstruct.CompiledFormat:
         """
         Converts a frame layout into a bitstructure formatting string
 
@@ -109,7 +111,7 @@ class LinUnconditionalFrame(LinFrame):
 
     def encode(self,
                data: Dict[str, Union[str, int, float]],
-               encoding_types: Dict[str, LinSignalEncodingType] = None) -> bytearray:
+               encoding_types: Dict[str, 'LinSignalEncodingType'] = None) -> bytearray:
         """
         Encodes signal values into the LIN frame content
 
@@ -194,7 +196,7 @@ class LinUnconditionalFrame(LinFrame):
 
     def decode(self,
                data: bytearray,
-               encoding_types: Dict[str, LinSignalEncodingType] = None,
+               encoding_types: Dict[str, 'LinSignalEncodingType'] = None,
                keep_unit: bool = False) -> Dict[str, Union[str, int, float]]:
         """
         Decodes a LIN frame into the signals that it contains
@@ -268,7 +270,7 @@ class LinUnconditionalFrame(LinFrame):
 
     def data(self,
              data: Dict[str, Union[str, int, float]],
-             converters: Dict[str, LinSignalEncodingType]) -> bytearray:
+             converters: Dict[str, 'LinSignalEncodingType']) -> bytearray:
         """
         Returns a bytearray (frame content) by using the human readable signal values
 
@@ -299,7 +301,7 @@ class LinUnconditionalFrame(LinFrame):
 
     def parse(self,
               data: bytearray,
-              converters: Dict[str, LinSignalEncodingType]) -> Dict[str, Union[str, int, float]]:
+              converters: Dict[str, 'LinSignalEncodingType']) -> Dict[str, Union[str, int, float]]:
         """
         Returns a mapping between Signal names and their human readable value
 
@@ -323,8 +325,9 @@ class LinEventTriggeredFrame(LinFrame):
     LinEventTriggeredFrame is LinFrame in the schedule table that can contain different
     unconditional frames from different nodes
     """
-    # TODO: add schedule table reference
 
-    def __init__(self, frame_id: int, name: str, frames: List[LinUnconditionalFrame]) -> None:
+    def __init__(self, frame_id: int, name: str, frames: List[LinUnconditionalFrame],
+                 collision_resolving_schedule_table: 'ScheduleTable' = None) -> None:
         super().__init__(frame_id, name)
         self.frames = frames
+        self.collision_resolving_schedule_table = collision_resolving_schedule_table

--- a/ldfparser/ldf.py
+++ b/ldfparser/ldf.py
@@ -9,6 +9,7 @@ from .diagnostics import LinDiagnosticFrame, LinDiagnosticRequest, LinDiagnostic
 from .signal import LinSignal
 from .encoding import LinSignalEncodingType
 from .node import LinMaster, LinSlave
+from .schedule import ScheduleTable
 
 class LDF():
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
@@ -33,6 +34,7 @@ class LDF():
         self._signal_representations: Dict[LinSignal, LinSignalEncodingType] = {}
         self._master_request_frame: LinDiagnosticRequest = None
         self._slave_response_frame: LinDiagnosticResponse = None
+        self._schedule_tables: Dict[str, ScheduleTable] = {}
         self._comments: List[str] = []
 
     def get_protocol_version(self) -> LinVersion:
@@ -231,6 +233,30 @@ class LDF():
         :rtype: List[LinSignal]
         """
         return self._diagnostic_signals.values()
+
+    def get_schedule_table(self, name: str) -> ScheduleTable:
+        """
+        Returns the schedule table with the given name
+
+        :param name: Name of the schedule table to find
+        :type name: str
+        :returns: Schedule table
+        :rtype: ScheduleTable
+        :raises: LookupError if the given schedule table is not found
+        """
+        schedule = self._schedule_tables.get(name)
+        if schedule is None:
+            raise LookupError(f"No schedule table named '{name}' found!")
+        return schedule
+
+    def get_schedule_tables(self) -> List[ScheduleTable]:
+        """
+        Returns all schedule tables
+
+        :returns: List of Schedule tables
+        :rtype: List[ScheduleTable]
+        """
+        return self._schedule_tables.values()
 
     @property
     def master_request_frame(self) -> LinDiagnosticRequest:

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -190,7 +190,7 @@ def _populate_diagnostic_frames(json: dict, ldf: LDF):
             if frame['frame_id'] == LIN_SLAVE_RESPONSE_FRAME_ID:
                 ldf._slave_response_frame = LinDiagnosticResponse(frame_obj)
 
-def _create_schedule_table_entry(json: dict, ldf: LDF):
+def _create_schedule_table_entry(json: dict, ldf: LDF):  # noqa: C901
     if json['command']['type'] == 'frame':
         entry = LinFrameEntry()
         entry.delay = json['delay']

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -71,6 +71,7 @@ def parse_ldf(path: str, capture_comments: bool = False, encoding: str = None) -
 
     _link_ldf_signals(json, ldf)
     _link_ldf_frames(json, ldf)
+    _link_ldf_schedule_table(json, ldf)
 
     if capture_comments:
         ldf._comments = json['comments']
@@ -318,6 +319,13 @@ def _link_ldf_frames(json: dict, ldf: LDF):
                 raise ValueError(f"Frame {frame_obj.name} references non existent node {frame['publisher']}")
             slave.publishes_frames.append(frame_obj)
             frame_obj.publisher = slave
+
+def _link_ldf_schedule_table(json: dict, ldf: LDF):
+    if "event_triggered_frames" not in json:
+        return
+    for frame in json['event_triggered_frames']:
+        frame_obj = ldf.get_event_triggered_frame(frame['name'])
+        frame_obj.collision_resolving_schedule_table = ldf.get_schedule_table(frame['collision_resolving_schedule_table'])
 
 def _populate_ldf_encoding_types(json: dict, ldf: LDF):
     if json.get('signal_encoding_types') is None or json.get('signal_representations') is None:

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -534,7 +534,7 @@ class LDFTransformer(Transformer):
         return {"name": tree[0], "schedule": tree[1:]}
 
     def schedule_table_entry(self, tree):
-        return {"command": tree[0], "delay": tree[1]}
+        return {"command": tree[0], "delay": tree[1] * 0.001}
 
     def schedule_table_command(self, tree):
         return tree[0]

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -3,7 +3,8 @@ import warnings
 from typing import Any, Dict, List
 from lark import Lark, Transformer
 
-from ldfparser.diagnostics import LIN_MASTER_REQUEST_FRAME_ID, LIN_SLAVE_RESPONSE_FRAME_ID, LinDiagnosticFrame, LinDiagnosticRequest, LinDiagnosticResponse
+from .diagnostics import LIN_MASTER_REQUEST_FRAME_ID, LIN_SLAVE_RESPONSE_FRAME_ID, LinDiagnosticFrame, LinDiagnosticRequest, LinDiagnosticResponse
+from .schedule import AssignFrameIdEntry, AssignFrameIdRangeEntry, AssignNadEntry, ConditionalChangeNadEntry, DataDumpEntry, FreeFormatEntry, MasterRequestEntry, SaveConfigurationEntry, ScheduleTable, SlaveResponseEntry, UnassignFrameIdEntry, LinFrameEntry
 
 from .frame import LinEventTriggeredFrame, LinUnconditionalFrame
 from .signal import LinSignal
@@ -66,6 +67,7 @@ def parse_ldf(path: str, capture_comments: bool = False, encoding: str = None) -
     _populate_diagnostic_frames(json, ldf)
     _populate_ldf_nodes(json, ldf)
     _populate_ldf_encoding_types(json, ldf)
+    _populate_schedule_tables(json, ldf)
 
     _link_ldf_signals(json, ldf)
     _link_ldf_frames(json, ldf)
@@ -187,6 +189,81 @@ def _populate_diagnostic_frames(json: dict, ldf: LDF):
                 ldf._master_request_frame = LinDiagnosticRequest(frame_obj)
             if frame['frame_id'] == LIN_SLAVE_RESPONSE_FRAME_ID:
                 ldf._slave_response_frame = LinDiagnosticResponse(frame_obj)
+
+def _create_schedule_table_entry(json: dict, ldf: LDF):
+    if json['command']['type'] == 'frame':
+        entry = LinFrameEntry()
+        entry.delay = json['delay']
+        entry.frame = ldf.get_frame(json['command']['frame'])
+        return entry
+    if json['command']['type'] == 'master_request':
+        entry = MasterRequestEntry()
+        entry.delay = json['delay']
+        return entry
+    if json['command']['type'] == 'slave_response':
+        entry = SlaveResponseEntry()
+        entry.delay = json['delay']
+        return entry
+    if json['command']['type'] == 'assign_nad':
+        entry = AssignNadEntry()
+        entry.delay = json['delay']
+        entry.node = ldf.get_slave(json['command']['node'])
+        return entry
+    if json['command']['type'] == 'conditional_change_nad':
+        entry = ConditionalChangeNadEntry()
+        entry.delay = json['delay']
+        entry.nad = json['command']['nad']
+        entry.id = json['command']['id']
+        entry.byte = json['command']['byte']
+        entry.mask = json['command']['mask']
+        entry.inv = json['command']['inv']
+        entry.new_nad = json['command']['new_nad']
+        return entry
+    if json['command']['type'] == 'data_dump':
+        entry = DataDumpEntry()
+        entry.delay = json['delay']
+        entry.node = ldf.get_slave(json['command']['node'])
+        entry.data = json['command']['data']
+        return entry
+    if json['command']['type'] == 'save_configuration':
+        entry = SaveConfigurationEntry()
+        entry.delay = json['delay']
+        entry.node = ldf.get_slave(json['command']['node'])
+        return entry
+    if json['command']['type'] == 'assign_frame_id':
+        entry = AssignFrameIdEntry()
+        entry.delay = json['delay']
+        entry.node = ldf.get_slave(json['command']['node'])
+        entry.frame = ldf.get_frame(json['command']['frame'])
+        return entry
+    if json['command']['type'] == 'unassign_frame_id':
+        entry = UnassignFrameIdEntry()
+        entry.delay = json['delay']
+        entry.node = ldf.get_slave(json['command']['node'])
+        entry.frame = ldf.get_frame(json['command']['frame'])
+        return entry
+    if json['command']['type'] == 'assign_frame_id_range':
+        entry = AssignFrameIdRangeEntry()
+        entry.delay = json['delay']
+        entry.node = ldf.get_slave(json['command']['node'])
+        entry.frame_index = json['command']['frame_index']
+        entry.pids = json['command']['pids']
+        return entry
+    if json['command']['type'] == 'free_format':
+        entry = FreeFormatEntry()
+        entry.delay = json['delay']
+        entry.data = json['command']['data']
+        return entry
+    raise ValueError("Unknown schedule command type")
+
+def _populate_schedule_tables(json: dict, ldf: LDF):
+    if 'schedule_tables' in json:
+        for table in json['schedule_tables']:
+            schedule_table = ScheduleTable(table['name'])
+            for item in table['schedule']:
+                entry = _create_schedule_table_entry(item, ldf)
+                schedule_table.schedule.append(entry)
+            ldf._schedule_tables[schedule_table.name] = schedule_table
 
 def _link_ldf_signals(json: dict, ldf: LDF):  # noqa: C901
     for signal in _require_key(json, 'signals', 'LDF missing Signals section.'):

--- a/ldfparser/schedule.py
+++ b/ldfparser/schedule.py
@@ -13,7 +13,7 @@ class ScheduleTable():
 class ScheduleTableEntry():
 
     def __init__(self) -> None:
-        self.delay: int = 0
+        self.delay: float = 0.0
 
 class LinFrameEntry(ScheduleTableEntry):
 

--- a/ldfparser/schedule.py
+++ b/ldfparser/schedule.py
@@ -1,8 +1,9 @@
 
-from typing import List
+from typing import List, TYPE_CHECKING
 
-from .frame import LinFrame
-from .node import LinNode
+if TYPE_CHECKING:
+    from .frame import LinFrame
+    from .node import LinNode
 
 class ScheduleTable():
 
@@ -19,7 +20,7 @@ class LinFrameEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()
-        self.frame: LinFrame = None
+        self.frame: 'LinFrame' = None
 
 class MasterRequestEntry(ScheduleTableEntry):
 
@@ -35,13 +36,13 @@ class AssignNadEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()
-        self.node: LinNode = None
+        self.node: 'LinNode' = None
 
 class AssignFrameIdRangeEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()
-        self.node: LinNode = None
+        self.node: 'LinNode' = None
         self.frame_index: int = 0
         self.pids: List[int] = []
 
@@ -60,28 +61,28 @@ class DataDumpEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()
-        self.node: LinNode = None
+        self.node: 'LinNode' = None
         self.data: List[int] = []
 
 class SaveConfigurationEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()
-        self.node: LinNode = None
+        self.node: 'LinNode' = None
 
 class AssignFrameIdEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()
-        self.node: LinNode = None
-        self.frame: LinFrame = None
+        self.node: 'LinNode' = None
+        self.frame: 'LinFrame' = None
 
 class UnassignFrameIdEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()
-        self.node: LinNode = None
-        self.frame: LinFrame = None
+        self.node: 'LinNode' = None
+        self.frame: 'LinFrame' = None
 
 class FreeFormatEntry(ScheduleTableEntry):
 

--- a/ldfparser/schedule.py
+++ b/ldfparser/schedule.py
@@ -13,9 +13,9 @@ class ScheduleTable():
 class ScheduleTableEntry():
 
     def __init__(self) -> None:
-        self.delay = 0
+        self.delay: int = 0
 
-class UnconditionalFrameEntry(ScheduleTableEntry):
+class LinFrameEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()
@@ -42,7 +42,8 @@ class AssignFrameIdRangeEntry(ScheduleTableEntry):
     def __init__(self) -> None:
         super().__init__()
         self.node: LinNode = None
-        self.pids = []
+        self.frame_index: int = 0
+        self.pids: List[int] = []
 
 class ConditionalChangeNadEntry(ScheduleTableEntry):
 
@@ -69,6 +70,13 @@ class SaveConfigurationEntry(ScheduleTableEntry):
         self.node: LinNode = None
 
 class AssignFrameIdEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.node: LinNode = None
+        self.frame: LinFrame = None
+
+class UnassignFrameIdEntry(ScheduleTableEntry):
 
     def __init__(self) -> None:
         super().__init__()

--- a/ldfparser/schedule.py
+++ b/ldfparser/schedule.py
@@ -1,0 +1,82 @@
+
+from typing import List
+
+from .frame import LinFrame
+from .node import LinNode
+
+class ScheduleTable():
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.schedule: List[ScheduleTableEntry] = []
+
+class ScheduleTableEntry():
+
+    def __init__(self) -> None:
+        self.delay = 0
+
+class UnconditionalFrameEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.frame: LinFrame = None
+
+class MasterRequestEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+class SlaveResponseEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+class AssignNadEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.node: LinNode = None
+
+class AssignFrameIdRangeEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.node: LinNode = None
+        self.pids = []
+
+class ConditionalChangeNadEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.nad: int = 0
+        self.id: int = 0
+        self.byte: int = 0
+        self.mask: int = 0
+        self.inv: int = 0
+        self.new_nad: int = 0
+
+class DataDumpEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.node: LinNode = None
+        self.data: List[int] = []
+
+class SaveConfigurationEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.node: LinNode = None
+
+class AssignFrameIdEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.node: LinNode = None
+        self.frame: LinFrame = None
+
+class FreeFormatEntry(ScheduleTableEntry):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.data: List[int] = []

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -387,6 +387,21 @@
                 }
             }
         },
+        "unassign_frame_id_entry": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "unassign_frame_id"
+                },
+                "node": {
+                    "type": "string"
+                },
+                "frame": {
+                    "type": "string"
+                }
+            }
+        },
         "free_format_entry": {
             "type": "object",
             "properties": {
@@ -454,6 +469,9 @@
                         },
                         {
                             "$ref": "#/definitions/assign_frame_id_entry"
+                        },
+                        {
+                            "$ref": "#/definitions/unassign_frame_id_entry"
                         },
                         {
                             "$ref": "#/definitions/free_format_entry"

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -488,7 +488,7 @@
                     ]
                 },
                 "delay": {
-                    "type": "integer"
+                    "type": "number"
                 }
             }
         },

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.12.0
+version = 0.13.0-rc1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.13.0-rc1
+version = 0.13.0

--- a/tests/ldf/lin_schedules.ldf
+++ b/tests/ldf/lin_schedules.ldf
@@ -1,0 +1,103 @@
+LIN_description_file;
+LIN_protocol_version = "2.1";
+LIN_language_version = "2.1";
+LIN_speed = 19.2 kbps;
+
+Nodes {
+    Master: LightController, 5 ms, 1 ms ;
+    Slaves: LeftLight, RightLight;
+}
+
+Node_attributes {
+    LeftLight {
+        LIN_protocol = "2.1";
+        configured_NAD = 0x20;
+        initial_NAD = 0x01;
+        product_id = 0x4A4F, 0x4841;
+        configurable_frames {
+            LeftLightStatus; LeftLightSet; LeftLightError;
+        }
+    }
+    RightLight {
+        LIN_protocol = "2.1";
+        configured_NAD = 0x21;
+        initial_NAD = 0x02;
+        product_id = 0x4A4F, 0x4841;
+        configurable_frames {
+            RightLightStatus; RightLightSet; RightLightError;
+        }
+    }
+}
+
+Signals {
+    LeftLight_signal: 8, 0xFF, LeftLight, LightController;
+    SetLeftLight_signal: 8, 0xFF, LightController, LeftLight;
+    LeftLightError_signal: 1, 0, LeftLight, LightController;
+
+    RightLight_signal: 8, 0xFF, RightLight, LightController;
+    SetRightLight_signal: 8, 0xFF, LightController, RightLight;
+    RightLightError_signal: 1, 0, RightLight, LightController;
+}
+
+Frames {
+    LeftLightStatus: 0x40, LeftLight, 8 {
+        LeftLight_signal, 0;
+    }
+    RightLightStatus: 0x41, RightLight, 8 {
+        RightLight_signal, 0;
+    }
+    LeftLightSet: 0x42, LightController, 8 {
+        SetLeftLight_signal, 0;
+    }
+    RightLightSet: 0x43, LightController, 8 {
+        SetRightLight_signal, 0;
+    }
+    LeftLightError: 0x44, LeftLight, 8 {
+        LeftLightError_signal, 0;
+    }
+    RightLightError: 0x45, RightLight, 8 {
+        RightLightError_signal, 0;
+    }
+}
+
+Event_triggered_frames {
+    LightErrorEvent : Collision_resolver, 0x39, LeftLightError, RightLightError;
+}
+
+Schedule_tables {
+    AddressConfiguration_Schedule {
+        AssignNAD { LeftLight } delay 10 ms;
+        SaveConfiguration { LeftLight } delay 10 ms;
+        AssignNAD { RightLight } delay 10 ms;
+        SaveConfiguration { RightLight } delay 10 ms;
+
+        ConditionalChangeNAD { 0x7F, 0x01, 0x03, 0x01, 0xFF, 0x01 } delay 10 ms;
+    }
+    FrameConfiguration_Schedule {
+        AssignFrameIdRange { LeftLight, 0, 0x40, 0x42, 0xFF, 0xFF } delay 10 ms;
+        SaveConfiguration { LeftLight } delay 10 ms;
+        AssignFrameIdRange { RightLight, 0, 0x41, 0x43, 0xFF, 0xFF } delay 10 ms;
+        SaveConfiguration { RightLight } delay 10 ms;
+
+        AssignFrameId { LeftLight, LeftLightStatus } delay 10ms;
+        AssignFrameId { RightLight, RightLightStatus } delay 10ms;
+
+        UnassignFrameId { LeftLight, LeftLightStatus } delay 10ms;
+        UnassignFrameId { RightLight, RightLightStatus } delay 10ms;
+    }
+    InformationSchedule {
+        DataDump { LeftLight, 0x10, 0x80, 0x00, 0xFF, 0xFF } delay 10 ms;
+        DataDump { RightLight, 0x10, 0x80, 0x00, 0xFF, 0xFF } delay 10 ms;
+        FreeFormat { 0x3C, 0xB2, 0x00, 0x00, 0xFF, 0x7F, 0xFF, 0xFF} delay 10ms;
+    }
+    Diagnostic_Schedule {
+        MasterReq delay 10 ms;
+        SlaveResp delay 10 ms;
+    }
+    Normal_Schedule {
+        LeftLightSet delay 20 ms;
+        LeftLightStatus delay 20 ms;
+        RightLightSet delay 20 ms;
+        RightLightStatus delay 20 ms;
+    }
+}

--- a/tests/ldf/lin_schedules.ldf
+++ b/tests/ldf/lin_schedules.ldf
@@ -80,15 +80,15 @@ Schedule_tables {
         SaveConfiguration { RightLight } delay 10 ms;
 
         AssignFrameId { LeftLight, LeftLightStatus } delay 10ms;
-        AssignFrameId { RightLight, RightLightStatus } delay 10ms;
-
         UnassignFrameId { LeftLight, LeftLightStatus } delay 10ms;
+
+        AssignFrameId { RightLight, RightLightStatus } delay 10ms;
         UnassignFrameId { RightLight, RightLightStatus } delay 10ms;
     }
     InformationSchedule {
         DataDump { LeftLight, 0x10, 0x80, 0x00, 0xFF, 0xFF } delay 10 ms;
         DataDump { RightLight, 0x10, 0x80, 0x00, 0xFF, 0xFF } delay 10 ms;
-        FreeFormat { 0x3C, 0xB2, 0x00, 0x00, 0xFF, 0x7F, 0xFF, 0xFF} delay 10ms;
+        FreeFormat { 0x3C, 0xB2, 0x00, 0x00, 0xFF, 0x7F, 0xFF, 0xFF } delay 10ms;
     }
     Diagnostic_Schedule {
         MasterReq delay 10 ms;

--- a/tests/ldf/lin_schedules.ldf
+++ b/tests/ldf/lin_schedules.ldf
@@ -61,7 +61,7 @@ Frames {
 }
 
 Event_triggered_frames {
-    LightErrorEvent : Collision_resolver, 0x39, LeftLightError, RightLightError;
+    LightErrorEvent : Collision_Resolver_Schedule, 0x39, LeftLightError, RightLightError;
 }
 
 Schedule_tables {
@@ -85,7 +85,7 @@ Schedule_tables {
         AssignFrameId { RightLight, RightLightStatus } delay 10ms;
         UnassignFrameId { RightLight, RightLightStatus } delay 10ms;
     }
-    InformationSchedule {
+    Information_Schedule {
         DataDump { LeftLight, 0x10, 0x80, 0x00, 0xFF, 0xFF } delay 10 ms;
         DataDump { RightLight, 0x10, 0x80, 0x00, 0xFF, 0xFF } delay 10 ms;
         FreeFormat { 0x3C, 0xB2, 0x00, 0x00, 0xFF, 0x7F, 0xFF, 0xFF } delay 10ms;
@@ -99,5 +99,9 @@ Schedule_tables {
         LeftLightStatus delay 20 ms;
         RightLightSet delay 20 ms;
         RightLightStatus delay 20 ms;
+    }
+    Collision_Resolver_Schedule {
+        LeftLightError delay 10 ms;
+        RightLightError delay 10 ms;
     }
 }

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 from ldfparser.parser import parse_ldf
-from ldfparser.schedule import AssignNadEntry, ConditionalChangeNadEntry, SaveConfigurationEntry
+from ldfparser.schedule import AssignFrameIdEntry, AssignFrameIdRangeEntry, AssignNadEntry, ConditionalChangeNadEntry, DataDumpEntry, FreeFormatEntry, LinFrameEntry, MasterRequestEntry, SaveConfigurationEntry, SlaveResponseEntry, UnassignFrameIdEntry
 
 class TestSchedule:
 
@@ -12,7 +12,7 @@ class TestSchedule:
         ldf = parse_ldf(path)
 
         assert len(ldf.get_schedule_tables()) == 5
-        
+
         address_config_table = ldf.get_schedule_table('AddressConfiguration_Schedule')
         assert len(address_config_table.schedule) == 5
 
@@ -35,3 +35,50 @@ class TestSchedule:
         assert entry_5.mask == 0x01
         assert entry_5.inv == 0xFF
         assert entry_5.new_nad == 0x01
+
+        frame_config_table = ldf.get_schedule_table('FrameConfiguration_Schedule')
+        assert len(frame_config_table.schedule) == 8
+
+        entry_1 = frame_config_table.schedule[0]
+        assert isinstance(entry_1, AssignFrameIdRangeEntry)
+        assert entry_1.node.name == 'LeftLight'
+        assert entry_1.frame_index == 0
+        assert entry_1.pids == [0x40, 0x42, 0xFF, 0xFF]
+
+        entry_5 = frame_config_table.schedule[4]
+        assert isinstance(entry_5, AssignFrameIdEntry)
+        assert entry_5.node.name == 'LeftLight'
+        assert entry_5.frame.name == 'LeftLightStatus'
+
+        entry_6 = frame_config_table.schedule[5]
+        assert isinstance(entry_6, UnassignFrameIdEntry)
+        assert entry_6.node.name == 'LeftLight'
+        assert entry_6.frame.name == 'LeftLightStatus'
+
+        information_schedule = ldf.get_schedule_table('InformationSchedule')
+        assert len(information_schedule.schedule) == 3
+
+        entry_1 = information_schedule.schedule[0]
+        assert isinstance(entry_1, DataDumpEntry)
+        assert entry_1.node.name == 'LeftLight'
+        assert entry_1.data == [0x10, 0x80, 0x00, 0xFF, 0xFF]
+
+        entry_3 = information_schedule.schedule[2]
+        assert isinstance(entry_3, FreeFormatEntry)
+        assert entry_3.data == [0x3C, 0xB2, 0x00, 0x00, 0xFF, 0x7F, 0xFF, 0xFF]
+
+        diagnostic_schedule = ldf.get_schedule_table('Diagnostic_Schedule')
+        assert len(diagnostic_schedule.schedule) == 2
+
+        entry_1 = diagnostic_schedule.schedule[0]
+        assert isinstance(entry_1, MasterRequestEntry)
+
+        entry_2 = diagnostic_schedule.schedule[1]
+        assert isinstance(entry_2, SlaveResponseEntry)
+
+        normal_schedule = ldf.get_schedule_table('Normal_Schedule')
+        assert len(normal_schedule.schedule) == 4
+
+        entry_1 = normal_schedule.schedule[0]
+        assert isinstance(entry_1, LinFrameEntry)
+        assert entry_1.frame.name == 'LeftLightSet'

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -18,17 +18,17 @@ class TestSchedule:
 
         entry_1 = address_config_table.schedule[0]
         assert isinstance(entry_1, AssignNadEntry)
-        assert entry_1.delay == 10
+        assert entry_1.delay == 0.010
         assert entry_1.node.name == 'LeftLight'
 
         entry_2 = address_config_table.schedule[1]
         assert isinstance(entry_2, SaveConfigurationEntry)
-        assert entry_2.delay == 10
+        assert entry_2.delay == 0.010
         assert entry_2.node.name == 'LeftLight'
 
         entry_5 = address_config_table.schedule[4]
         assert isinstance(entry_5, ConditionalChangeNadEntry)
-        assert entry_5.delay == 10
+        assert entry_5.delay == 0.010
         assert entry_5.nad == 0x7F
         assert entry_5.id == 0x01
         assert entry_5.byte == 0x03

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -2,7 +2,10 @@ import os
 import pytest
 
 from ldfparser.parser import parse_ldf
-from ldfparser.schedule import AssignFrameIdEntry, AssignFrameIdRangeEntry, AssignNadEntry, ConditionalChangeNadEntry, DataDumpEntry, FreeFormatEntry, LinFrameEntry, MasterRequestEntry, SaveConfigurationEntry, SlaveResponseEntry, UnassignFrameIdEntry
+from ldfparser.schedule import (AssignFrameIdEntry, AssignFrameIdRangeEntry, AssignNadEntry,
+                                ConditionalChangeNadEntry, DataDumpEntry, FreeFormatEntry,
+                                LinFrameEntry, MasterRequestEntry,
+                                SaveConfigurationEntry, SlaveResponseEntry, UnassignFrameIdEntry)
 
 class TestSchedule:
 
@@ -85,3 +88,6 @@ class TestSchedule:
 
         event_frame = ldf.get_event_triggered_frame('LightErrorEvent')
         assert event_frame.collision_resolving_schedule_table.name == 'Collision_Resolver_Schedule'
+
+        with pytest.raises(LookupError):
+            ldf.get_schedule_table('NotExistingSchedule')

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+
+from ldfparser.parser import parse_ldf
+from ldfparser.schedule import AssignNadEntry, ConditionalChangeNadEntry, SaveConfigurationEntry
+
+class TestSchedule:
+
+    @pytest.mark.unit
+    def test_schedule_load(self):
+        path = os.path.join(os.path.dirname(__file__), "ldf", "lin_schedules.ldf")
+        ldf = parse_ldf(path)
+
+        assert len(ldf.get_schedule_tables()) == 5
+        
+        address_config_table = ldf.get_schedule_table('AddressConfiguration_Schedule')
+        assert len(address_config_table.schedule) == 5
+
+        entry_1 = address_config_table.schedule[0]
+        assert isinstance(entry_1, AssignNadEntry)
+        assert entry_1.delay == 10
+        assert entry_1.node.name == 'LeftLight'
+
+        entry_2 = address_config_table.schedule[1]
+        assert isinstance(entry_2, SaveConfigurationEntry)
+        assert entry_2.delay == 10
+        assert entry_2.node.name == 'LeftLight'
+
+        entry_5 = address_config_table.schedule[4]
+        assert isinstance(entry_5, ConditionalChangeNadEntry)
+        assert entry_5.delay == 10
+        assert entry_5.nad == 0x7F
+        assert entry_5.id == 0x01
+        assert entry_5.byte == 0x03
+        assert entry_5.mask == 0x01
+        assert entry_5.inv == 0xFF
+        assert entry_5.new_nad == 0x01

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -11,7 +11,7 @@ class TestSchedule:
         path = os.path.join(os.path.dirname(__file__), "ldf", "lin_schedules.ldf")
         ldf = parse_ldf(path)
 
-        assert len(ldf.get_schedule_tables()) == 5
+        assert len(ldf.get_schedule_tables()) == 6
 
         address_config_table = ldf.get_schedule_table('AddressConfiguration_Schedule')
         assert len(address_config_table.schedule) == 5
@@ -55,7 +55,7 @@ class TestSchedule:
         assert entry_6.node.name == 'LeftLight'
         assert entry_6.frame.name == 'LeftLightStatus'
 
-        information_schedule = ldf.get_schedule_table('InformationSchedule')
+        information_schedule = ldf.get_schedule_table('Information_Schedule')
         assert len(information_schedule.schedule) == 3
 
         entry_1 = information_schedule.schedule[0]
@@ -82,3 +82,6 @@ class TestSchedule:
         entry_1 = normal_schedule.schedule[0]
         assert isinstance(entry_1, LinFrameEntry)
         assert entry_1.frame.name == 'LeftLightSet'
+
+        event_frame = ldf.get_event_triggered_frame('LightErrorEvent')
+        assert event_frame.collision_resolving_schedule_table.name == 'Collision_Resolver_Schedule'


### PR DESCRIPTION
## Brief

+ Schedule tables are parsed into the intermediate dictionary but they're not converted into Python objects afterwards
+ This information could be used by a LIN master device or a network simulator to perform the requested schedule
+ The way these master APIs work shall be taken into account

### Checklist

- [x] Check test result and code coverage
- [x] Update documentation
- [x] Update changelog
- [x] Update version number

## Solves

+ Resolves #79

## Evidence

+ Feature is completely new therefore no breaking changes are expected
