### PR TITLE
Fixes function name in schedule table example

### DIFF
--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -13,7 +13,7 @@ be accessible.
 ```python
 ldf = parse_ldf('network.ldf')
 
-configuration_schedule = ldf.get_schedule('Configuration_Schedule')
+configuration_schedule = ldf.get_schedule_table('Configuration_Schedule')
 print(configuration_schedule.name)
 >>> 'Configuration_Schedule'
 for entry in configuration_schedule.schedule:


### PR DESCRIPTION
## Brief

- Function name in the documentation showing how to use schedule table information is wrong

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [ ] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [x] Update documentation
  - [ ] Update examples in README
- [ ] Update changelog
- [ ] Update version number

## Resolves

<!--
     Use the syntax: "Fixes #42" or "Resolves #42" to automatically link to issues.
 -->

+ Fixes #86 

