### PR TITLE
Fixes slave timeout default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2022-02-12
+
+### Fixed
+
+- `P2_min`, `ST_min` and `N_As` and `N_Cr` timeout default values are now set correctly
+
 ## [0.13.0] - 2022-02-05
 
 ### Added

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -161,10 +161,10 @@ def _create_ldf2x_node(node: dict, language_version: float):
     elif language_version >= LIN_VERSION_2_1:
         raise ValueError(f"Node {name} has no product_id specified, required for LDF 2.1+")
 
-    slave.p2_min = node.get('P2_min', None)
-    slave.st_min = node.get('ST_min', None)
-    slave.n_as_timeout = node.get('N_As_timeout', None)
-    slave.n_cr_timeout = node.get('N_Cr_timeout', None)
+    slave.p2_min = node.get('P2_min', 0.05)
+    slave.st_min = node.get('ST_min', 0)
+    slave.n_as_timeout = node.get('N_As_timeout', 1)
+    slave.n_cr_timeout = node.get('N_Cr_timeout', 1)
 
     return slave
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.13.0
+version = 0.13.1


### PR DESCRIPTION
## Brief

- The `P2_min`, `ST_min` and `N_As`, `N_Cr` timeouts are set incorrectly when the values are not provided in the LDF,
this is because the parser uses `None` as the default, but the `LinSlave` class had the correct defaults.

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [x] Update version number

## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ No significant changes are expected
