### PR TITLE
Signals now reference the Frame they're in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2022-02-26
+
 ### Added
 
 - `LDF` objects can now be saved as `.ldf` files (experimental)
 - Encoding types now have references to the Signals it represents
 - `LDF` object now has functions to lookup encoding types
+- `LinSignal` now reference the `LinUnconditionalFrame` they're in
 
 ### Changed
 

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -118,7 +118,11 @@ def _populate_ldf_frames(json: dict, ldf: LDF):
             elif 48 <= frame['frame_id'] <= 63:
                 length = 8
 
-        ldf._unconditional_frames[frame['name']] = LinUnconditionalFrame(frame['frame_id'], frame['name'], length, signals)
+        frame_obj = LinUnconditionalFrame(frame['frame_id'], frame['name'], length, signals)
+        ldf._unconditional_frames[frame['name']] = frame_obj
+
+        for (_, signal) in signals.items():
+            signal.frame = frame_obj
 
 def _populate_ldf_event_triggered_frames(json: dict, ldf: LDF):
     if "event_triggered_frames" not in json:

--- a/ldfparser/signal.py
+++ b/ldfparser/signal.py
@@ -6,6 +6,7 @@ from typing import List, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     from .node import LinNode
     from .encoding import LinSignalEncodingType
+    from .frame import LinUnconditionalFrame
 
 class LinSignal:
     """
@@ -30,6 +31,7 @@ class LinSignal:
         self.publisher: 'LinNode' = None
         self.subscribers: List['LinNode'] = []
         self.encoding_type: 'LinSignalEncodingType' = None
+        self.frame: 'LinUnconditionalFrame' = None
 
     def __eq__(self, o: object) -> bool:
         if isinstance(o, LinSignal):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -121,6 +121,7 @@ def test_no_signal_subscribers():
 
     assert ldf.signal('DummySignal_0') is not None
     assert ldf.frame('DummyFrame') is not None
+    assert ldf.signal('DummySignal_0').frame.name == 'DummyFrame'
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Brief

- `LinFrame` does reference the `LinSignals` that are contained within, but this is not true in the opposite way
- According to the standard `LinSignal` to `LinFrame` is a 1-to-1 relation

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [x] Review test results and code coverage
  - [x] Review snapshot test results for deviations
- [x] Review code changes
  - [x] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [x] Update version number

## Resolves

<!--
     Use the syntax: "Fixes #42" or "Resolves #42" to automatically link to issues.
 -->

+ Fixes #93 
+ Discussed in #92 

## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ Parser tests have been extended to include frame reference checking
