### PR TITLE
Makes master and slaves declarations optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BCD values are now checked when decoding physical values
 
+### Changes
+
+- Master and slaves declarations are now optional
+
 ## [0.14.0] - 2022-02-26
 
 ### Added

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 5%
+        base: auto
+        if_not_found: failure

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,6 @@ coverage:
     project:
       default:
         target: 90%
-        threshold: 5%
+        threshold: 20%
         base: auto
         if_not_found: failure

--- a/ldfparser/grammar.py
+++ b/ldfparser/grammar.py
@@ -52,6 +52,10 @@ class LdfTransformer(Transformer):
         return ("channel_name", tree[0])
 
     def nodes(self, tree):
+        if len(tree) == 0:
+            return ("nodes", {})
+        if len(tree) == 1:
+            return ("nodes", {'master': tree[0]})
         return ("nodes", {'master': tree[0], 'slaves': tree[1]})
 
     def nodes_master(self, tree):

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -15,7 +15,7 @@ header_speed: "LIN_speed" "=" ldf_float "kbps" ";"
 header_channel: "Channel_name" "=" "\"" ldf_identifier "\"" ";"
 
 // LIN 2.1 Specification, section 9.2.2
-nodes: "Nodes" "{" nodes_master nodes_slaves "}"
+nodes: "Nodes" "{" nodes_master? nodes_slaves? "}"
 nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ";"
 nodes_slaves: "Slaves" ":" ldf_identifier ("," ldf_identifier)* ";"
 

--- a/ldfparser/templates/ldf.jinja2
+++ b/ldfparser/templates/ldf.jinja2
@@ -10,8 +10,12 @@ Channel_name = "{{ ldf.get_channel() }}";
 {%- endif %}
 
 Nodes {
+    {%- if ldf.get_master() %}
     Master: {{ ldf.get_master().name }}, {{ ldf.get_master().timebase * 1000 | float}} ms, {{ ldf.get_master().jitter * 1000 }} ms;
+    {%- endif %}
+    {%- if ldf.get_slaves() %}
     Slaves: {%- for slave in ldf.get_slaves() %} {{ slave.name }}{%- if not loop.last %},{% endif -%}{%- endfor -%};
+    {%- endif %}
 }
 
 {%- if ldf.get_language_version().major == 2 %}

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -591,10 +591,7 @@
                     "$ref": "#/definitions/slaves"
                 }
             },
-            "required": [
-                "master",
-                "slaves"
-            ]
+            "required": []
         },
         "signals": {
             "type": "array",

--- a/tests/ldf/no_signal_subscribers.ldf
+++ b/tests/ldf/no_signal_subscribers.ldf
@@ -11,7 +11,6 @@ LIN_speed =  19.2 kbps;
 
 Nodes {
     Master: master, 5.0 ms, 0.1 ms;
-    Slaves: slave1;
 }
 
 Signals {
@@ -26,12 +25,6 @@ Frames {
 }
 
 Node_attributes {
-    // Empty
-    slave1 {
-        LIN_protocol = 2.0;
-        configured_NAD = 0x01;
-        product_id = 0x4A4F, 0x4841;
-    }
 }
 
 Schedule_tables {


### PR DESCRIPTION
## Brief

- Master and slave declarations (usually at the start of the LDF) are now optional

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [x] Review test results and code coverage
  - [x] Review snapshot test results for deviations
- [x] Review code changes
  - [x] Create relevant test scenarios
  - [ ] Update examples
  - [x] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [ ] Update version number

## Resolves

+ Resolves #95 

## Evidence

+ Existing LDFs are not affected but prototyping LDFs may now be parsed that lack node information
