### PR TITLE
Fixes release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Get version from tag
-        id: tag_name
-        run: echo "::set-output name=current_version::${GITHUB_REF#refs}"
-
-      - name: Print name
-        run: echo ${{ steps.tag_name.outputs.current_version }}
-
       - name: Install
         run: pip install -e .[dev]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Get version from tag
+        id: tag_name
+        run: echo "::set-output name=current_version::${GITHUB_REF#refs/tags/v}"
+
       - name: Install
         run: pip install -e .[dev]
 
@@ -175,7 +179,7 @@ jobs:
 
       - name: Get version from tag
         id: tag_name
-        run: echo "::set-output name=current_version::${GITHUB_REF/refs\/tags\/v/}"
+        run: echo "::set-output name=current_version::${GITHUB_REF#refs/tags/v}"
 
       - name: Read Changelog
         id: changelog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,10 @@ jobs:
 
       - name: Get version from tag
         id: tag_name
-        run: echo "::set-output name=current_version::${GITHUB_REF#refs/tags/v}"
+        run: echo "::set-output name=current_version::${GITHUB_REF#refs}"
+
+      - name: Print name
+        run: echo ${{ steps.tag_name.outputs.current_version }}
 
       - name: Install
         run: pip install -e .[dev]


### PR DESCRIPTION
## Brief

- Release job had the following error in the latest release, likely due to the command not working under Ubuntu shell.

```
Run echo "::set-output name=current_version::${GITHUB_REF/refs\/tags\/v/}"
  echo "::set-output name=current_version::${GITHUB_REF/refs\/tags\/v/}"
  shell: sh -e {0}
/__w/_temp/e1bb7b30-00e4-41a0-b76f-c[2](https://github.com/c4deszes/ldfparser/runs/7934175943?check_suite_focus=true#step:7:2)d865da2f[3](https://github.com/c4deszes/ldfparser/runs/7934175943?check_suite_focus=true#step:7:3)9.sh: 1: Bad substitution
Error: Process completed with exit code 2.
```

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [ ] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [ ] Update changelog
- [ ] Update version number
