### PR TITLE
Enforcing absolute paths when loading grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Path to the grammar and LDF template are now resolved absolute to allow using them in `pyinstaller`
+
 ## [0.15.0] - 2022-08-20
 
 ### Added

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -24,7 +24,7 @@ def parse_ldf_to_dict(path: str, capture_comments: bool = False, encoding: str =
     :type encoding: str
     """
     comments = []
-    lark = os.path.join(os.path.dirname(__file__), 'grammars', 'ldf.lark')
+    lark = os.path.abspath(os.path.join(os.path.dirname(__file__), 'grammars', 'ldf.lark'))
     parser = Lark(grammar=open(lark), parser='lalr', lexer_callbacks={
         'C_COMMENT': comments.append,
         'CPP_COMMENT': comments.append

--- a/ldfparser/save.py
+++ b/ldfparser/save.py
@@ -25,7 +25,7 @@ def save_ldf(ldf: LDF,
     :type template_path: PathLike
     """
     if template_path is None:
-        template_path = os.path.join(os.path.dirname(__file__), 'templates', 'ldf.jinja2')
+        template_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'templates', 'ldf.jinja2'))
 
     with open(template_path, 'r') as file:
         template = jinja2.Template(file.read())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.15.0
+version = 0.15.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.15.1
+version = 0.15.0


### PR DESCRIPTION
## Brief

- Parser and Save feature now use `os.path.abspath` in order to resolve issues with `pyinstaller` path resolution.

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [x] Review test results and code coverage
  - [x] Review snapshot test results for deviations
- [x] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [ ] Update version number

## Resolves

+ Resolves #104 

## Evidence

+ Standard Python installations should not be affected, absolute paths were already resolved there
