### PR TITLE
Adds diagnostic address parsing (LIN 1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2022-10-17
+
+### Added
+
+- Diagnostic addresses section in LIN 1.3 description files are now parsed correctly,
+  the `initial_nad` and `configured_nad` attributes will be set according to the address
+
 ## [0.16.0] - 2022-10-02
 
 ### Added

--- a/ldfparser/grammar.py
+++ b/ldfparser/grammar.py
@@ -134,6 +134,12 @@ class LdfTransformer(Transformer):
     def diagnostic_frame_signals(self, tree):
         return tree[0:]
 
+    def diagnostic_addresses(self, tree):
+        return ("diagnostic_addresses", dict(tree))
+
+    def diagnostic_address(self, tree):
+        return (tree[0], tree[1])
+
     def node_attributes(self, tree):
         return ("node_attributes", tree[0:])
 

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -1,6 +1,6 @@
 start: ldf
 
-ldf: (header_lin_description_file | header_protocol_version | header_language_version | header_speed | header_channel | nodes | node_compositions | signals | diagnostic_signals | frames | sporadic_frames | event_triggered_frames | diagnostic_frames | node_attributes | schedule_tables | signal_groups | signal_encoding_types | signal_representations)*
+ldf: (header_lin_description_file | header_protocol_version | header_language_version | header_speed | header_channel | nodes | node_compositions | signals | diagnostic_signals | diagnostic_addresses | frames | sporadic_frames | event_triggered_frames | diagnostic_frames | node_attributes | schedule_tables | signal_groups | signal_encoding_types | signal_representations)*
 
 ldf_identifier: CNAME
 ldf_version: C_VERSION
@@ -55,6 +55,10 @@ event_triggered_frame_definition_frames: ("," ldf_identifier)+
 diagnostic_frames: "Diagnostic_frames" "{" (diagnostic_frame_definition)+ "}"
 diagnostic_frame_definition: ldf_identifier ":" ldf_integer "{" diagnostic_frame_signals "}"
 diagnostic_frame_signals: (frame_signal+)
+
+// LIN 1.3 Specification, section 7.5
+diagnostic_addresses: "Diagnostic_addresses" "{" (diagnostic_address)* "}"
+diagnostic_address: ldf_identifier ":" ldf_integer ";"
 
 // LIN 2.1 Specification, section 9.2.2.2
 node_attributes: "Node_attributes" "{" (node_definition*) "}"

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -160,6 +160,9 @@ def _populate_ldf_nodes(json: dict, ldf: LDF):
                 node = LinSlave(slave)
                 node.lin_protocol = ldf.protocol_version
                 ldf._slaves[node.name] = node
+                if json.get('diagnostic_addresses') is not None and json['diagnostic_addresses'].get(node.name) is not None:
+                    node.initial_nad = json['diagnostic_addresses'][node.name]
+                    node.configured_nad = json['diagnostic_addresses'][node.name]
 
 def _create_ldf2x_node(node: dict, language_version: float):
     name = node['name']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.16.0
+version = 0.17.0

--- a/tests/ldf/lin13.ldf
+++ b/tests/ldf/lin13.ldf
@@ -11,6 +11,11 @@ Nodes {
     Slaves : LSM,CPM;
 }
 
+Diagnostic_addresses {
+    LSM: 1;
+    CPM: 0x02;
+}
+
 Signals {
     RearFogLampInd:1,0,CEM,LSM;
     PositionLampInd:1,0,CEM,LSM;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,6 +24,8 @@ def test_load_valid_lin13():
     assert ldf.frame('VL1_CEM_Frm1') is not None
     assert ldf.slave('LSM') is not None
 
+    assert ldf.get_slave('CPM').initial_nad == 0x02
+
 
 @pytest.mark.unit
 def test_load_valid_lin20():


### PR DESCRIPTION
## Brief

- Diagnostic address section was completely missing from the grammar, this PR resolves that

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [ ] Update changelog
- [x] Update version number

## Resolves

+ Fixes #107 

## Evidence

+ Snapshot results will deviate due to change in the test LDF files
