### PR TITLE
Removed tests from py-pkg | no open files after parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.18.0] - 2022-12-dd
+
+- Remove `tests` folder from python package
+- Close all files which are opened by the ldfparser
 
 ## [0.17.0] - 2022-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.18.0] - 2022-12-dd
+## [Unreleased]
+
+## [0.18.0] - 2022-12-13
+
+### Changed
 
 - Remove `tests` folder from python package
 - Close all files which are opened by the ldfparser

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -24,12 +24,15 @@ def parse_ldf_to_dict(path: str, capture_comments: bool = False, encoding: str =
     :type encoding: str
     """
     comments = []
-    lark = os.path.abspath(os.path.join(os.path.dirname(__file__), 'grammars', 'ldf.lark'))
-    parser = Lark(grammar=open(lark), parser='lalr', lexer_callbacks={
+    lark_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'grammars', 'ldf.lark'))
+    with open(lark_file, "r", encoding=encoding) as lark_file:
+        grammar = lark_file.read()
+    parser = Lark(grammar=grammar, parser='lalr', lexer_callbacks={
         'C_COMMENT': comments.append,
         'CPP_COMMENT': comments.append
     }, propagate_positions=True)
-    ldf_file = open(path, "r", encoding=encoding).read()
+    with open(path, "r", encoding=encoding) as input_file:
+        ldf_file = input_file.read()
     tree = parser.parse(ldf_file)
     json = LdfTransformer().transform(tree)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.17.0
+version = 0.18.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/c4deszes/ldfparser",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     package_data={'': ['*.lark']},
     license='MIT',
     keywords=['LIN', 'LDF'],


### PR DESCRIPTION
## Brief

I fixed a few bugs / "not-so-nice-things" during my first use of your library:
- Removed the tests folder from the python package
- Used everywhere `with open()` where files where opened to avoid opened files

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [ ] Add relevant labels to the Pull Request
- [x] Review test results and code coverage
  - [x] Review snapshot test results for deviations
- [x] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [x] Update version number

## Resolves

<!--
     Use the syntax: "Fixes #42" or "Resolves #42" to automatically link to issues.
 -->

+ Import from own `tests` folder is possible
+ No open files after .ldf parsing

## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ Analyze how the change might impact existing code -> there should be no impact

+ Provide evidence that the feature is tested and covered properly -> tested the change with my implementation
