### PR TITLE
ISO17987 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ISO17987 version support
+- Grammar support for the following ISO17987 fields:
+  - `LDF_file_revision`
+  - Endianness
+
 ## [0.18.0] - 2022-12-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `LDF_file_revision`
   - Endianness
 
+### Fixes
+
+- `LinSlave` protocol version property is now the correct type
+
 ## [0.18.0] - 2022-12-13
 
 ### Changed

--- a/ldfparser/__init__.py
+++ b/ldfparser/__init__.py
@@ -19,7 +19,7 @@ from .encoding import (PhysicalValue, LogicalValue, ASCIIValue, BCDValue,
 from .frame import LinEventTriggeredFrame, LinFrame, LinUnconditionalFrame
 from .ldf import LDF
 from .lin import (LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1,
-                  LIN_VERSION_2_2, LinVersion)
+                  LIN_VERSION_2_2, LinVersion, ISO17987_2015, Iso17987Version)
 from .node import (LinMaster, LinProductId, LinSlave,
                    LinNodeCompositionConfiguration, LinNodeComposition)
 from .parser import parse_ldf, parse_ldf_to_dict, parseLDF, parseLDFtoDict

--- a/ldfparser/grammar.py
+++ b/ldfparser/grammar.py
@@ -55,6 +55,15 @@ class LdfTransformer(Transformer):
     def header_channel(self, tree):
         return ("channel_name", tree[0])
 
+    def header_file_revision(self, tree):
+        return ("file_revision", tree[0])
+
+    def header_sig_byte_order_big_endian(self, tree):
+        return ("endianness", "big")
+
+    def header_sig_byte_order_little_endian(self, tree):
+        return ("endianness", "little")
+
     def nodes(self, tree):
         if len(tree) == 0:
             return ("nodes", {})

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -1,9 +1,9 @@
 start: ldf
 
-ldf: (header_lin_description_file | header_protocol_version | header_language_version | header_speed | header_channel | nodes | node_compositions | signals | diagnostic_signals | diagnostic_addresses | frames | sporadic_frames | event_triggered_frames | diagnostic_frames | node_attributes | schedule_tables | signal_groups | signal_encoding_types | signal_representations)*
+ldf: (header_lin_description_file | header_protocol_version | header_language_version | header_speed | header_channel | header_file_revision | header_sig_byte_order_big_endian | header_sig_byte_order_little_endian | nodes | node_compositions | signals | diagnostic_signals | diagnostic_addresses | frames | sporadic_frames | event_triggered_frames | diagnostic_frames | node_attributes | schedule_tables | signal_groups | signal_encoding_types | signal_representations)*
 
 ldf_identifier: CNAME
-ldf_version: C_VERSION
+ldf_version: LIN_VERSION | ISO_VERSION
 ldf_integer: C_INT
 ldf_float: C_FLOAT
 ldf_channel_name: ESCAPED_STRING
@@ -14,6 +14,11 @@ header_protocol_version: "LIN_protocol_version" "=" "\"" ldf_version "\"" ";"
 header_language_version: "LIN_language_version" "=" "\"" ldf_version "\"" ";"
 header_speed: "LIN_speed" "=" ldf_float "kbps" ";"
 header_channel: "Channel_name" "=" ldf_channel_name ";"
+
+// ISO1798 Specification
+header_file_revision: "LDF_file_revision" "=" ESCAPED_STRING ";"
+header_sig_byte_order_big_endian: "LIN_sig_byte_order_big_endian" ";"
+header_sig_byte_order_little_endian: "LIN_sig_byte_order_little_endian" ";"
 
 // LIN 2.1 Specification, section 9.2.2
 nodes: "Nodes" "{" nodes_master? nodes_slaves? "}"
@@ -113,7 +118,8 @@ signal_representation_node: ldf_identifier ":" ldf_identifier ("," ldf_identifie
 
 C_INT: ("0x"HEXDIGIT+) | ("-"? INT) 
 C_FLOAT: ("-"? INT ("." INT)?) ("e" ("+" | "-")? INT)?
-C_VERSION: INT "." INT
+LIN_VERSION: INT "." INT
+ISO_VERSION: "ISO17987" ":" INT
 
 ANY_SEMICOLON_TERMINATED_LINE: /.*;/
 

--- a/ldfparser/ldf.py
+++ b/ldfparser/ldf.py
@@ -3,7 +3,7 @@ Lin Description File handler objects
 """
 from typing import Union, Dict, List
 
-from .lin import LinVersion
+from .lin import LinVersion, Iso17987Version
 from .frame import LinFrame, LinSporadicFrame, LinUnconditionalFrame, LinEventTriggeredFrame
 from .diagnostics import LinDiagnosticFrame, LinDiagnosticRequest, LinDiagnosticResponse
 from .signal import LinSignal
@@ -19,8 +19,8 @@ class LDF():
 
     def __init__(self):
         self._source: Dict = None
-        self._protocol_version: LinVersion = None
-        self._language_version: LinVersion = None
+        self._protocol_version: Union[LinVersion, Iso17987Version] = None
+        self._language_version: Union[LinVersion, Iso17987Version] = None
         self._baudrate: int = None
         self._channel: str = None
         self._master: LinMaster = None
@@ -38,11 +38,11 @@ class LDF():
         self._schedule_tables: Dict[str, ScheduleTable] = {}
         self._comments: List[str] = []
 
-    def get_protocol_version(self) -> LinVersion:
+    def get_protocol_version(self) -> Union[LinVersion, Iso17987Version]:
         """Returns the protocol version of the LIN network"""
         return self._protocol_version
 
-    def get_language_version(self) -> LinVersion:
+    def get_language_version(self) -> Union[LinVersion, Iso17987Version]:
         """Returns the LDF language version"""
         return self._language_version
 

--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -1,6 +1,7 @@
 """
 Utility classes for LIN objects
 """
+from typing import Union
 
 class LinVersion:
     """
@@ -72,3 +73,56 @@ LIN_VERSION_1_3 = LinVersion(1, 3)
 LIN_VERSION_2_0 = LinVersion(2, 0)
 LIN_VERSION_2_1 = LinVersion(2, 1)
 LIN_VERSION_2_2 = LinVersion(2, 2)
+
+class Iso17987Version:
+    
+    def __init__(self, revision: int) -> None:
+        self.revision = revision
+    
+    @staticmethod
+    def from_string(version: str) -> 'Iso17987Version':
+        (standard, revision) = version.split(':')
+
+        return Iso17987Version(int(revision))
+
+    def __str__(self) -> str:
+        return f"ISO17987:{self.revision}"
+
+    def __eq__(self, o: object) -> bool:
+        if isinstance(o, Iso17987Version):
+            return self.revision == o.revision
+        return False
+
+    def __gt__(self, o) -> bool:
+        if isinstance(o, Iso17987Version):
+            return (self.revision > o.revision)
+        if isinstance(o, LinVersion):
+            return True
+        raise TypeError()
+
+    def __lt__(self, o) -> bool:
+        if isinstance(o, Iso17987Version):
+            return (self.revision < o.revision)
+        if isinstance(o, LinVersion):
+            return False
+        raise TypeError()
+
+    def __ge__(self, o) -> bool:
+        return not self.__lt__(o)
+
+    def __le__(self, o) -> bool:
+        return not self.__gt__(o)
+
+    def __ne__(self, o: object) -> bool:
+        return not self.__eq__(o)
+
+ISO17987_2015 = Iso17987Version(2015)
+
+def parse_lin_version(version: str) -> Union[LinVersion, Iso17987Version]:
+    try:
+        return LinVersion.from_string(version)
+    except ValueError:
+        try:
+            return Iso17987Version.from_string(version)
+        except ValueError:
+            raise ValueError(f'{version} is not a valid LIN version.')

--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -75,10 +75,10 @@ LIN_VERSION_2_1 = LinVersion(2, 1)
 LIN_VERSION_2_2 = LinVersion(2, 2)
 
 class Iso17987Version:
-    
+
     def __init__(self, revision: int) -> None:
         self.revision = revision
-    
+
     @staticmethod
     def from_string(version: str) -> 'Iso17987Version':
         (standard, revision) = version.split(':')

--- a/ldfparser/node.py
+++ b/ldfparser/node.py
@@ -1,12 +1,12 @@
 """
 LIN Node utilities
 """
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from .frame import LinFrame
     from .signal import LinSignal
-    from .lin import LinVersion
+    from .lin import LinVersion, Iso17987Version
 
 LIN_SUPPLIER_ID_WILDCARD = 0x7FFF
 LIN_FUNCTION_ID_WILDCARD = 0xFFFF
@@ -113,7 +113,7 @@ class LinSlave(LinNode):
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
-        self.lin_protocol: 'LinVersion' = None
+        self.lin_protocol: Union[LinVersion, Iso17987Version] = None
         self.configured_nad: int = None
         self.initial_nad: int = None
         self.product_id: LinProductId = None

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -9,7 +9,7 @@ from .schedule import AssignFrameIdEntry, AssignFrameIdRangeEntry, AssignNadEntr
 from .frame import LinEventTriggeredFrame, LinSporadicFrame, LinUnconditionalFrame
 from .signal import LinSignal
 from .encoding import ASCIIValue, BCDValue, LinSignalEncodingType, LogicalValue, PhysicalValue, ValueConverter
-from .lin import LIN_VERSION_2_0, LIN_VERSION_2_1, LinVersion
+from .lin import LIN_VERSION_2_0, LIN_VERSION_2_1, LinVersion, Iso17987Version, parse_lin_version
 from .node import LinMaster, LinProductId, LinSlave
 from .ldf import LDF
 from .grammar import LdfTransformer
@@ -92,8 +92,8 @@ def parseLDF(path: str, captureComments: bool = False, encoding: str = None) -> 
     return parse_ldf(path, captureComments, encoding)
 
 def _populate_ldf_header(json: dict, ldf: LDF):
-    ldf._protocol_version = LinVersion.from_string(_require_key(json, 'protocol_version', 'LDF missing protocol version.'))
-    ldf._language_version = LinVersion.from_string(_require_key(json, 'language_version', 'LDF missing language version.'))
+    ldf._protocol_version = parse_lin_version(_require_key(json, 'protocol_version', 'LDF missing protocol version.'))
+    ldf._language_version = parse_lin_version(_require_key(json, 'language_version', 'LDF missing language version.'))
     ldf._baudrate = _require_key(json, 'speed', 'LDF missing speed definition.')
     ldf._channel = json.get('channel_name')
 

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -171,7 +171,7 @@ def _create_ldf2x_node(node: dict, language_version: float):
     name = node['name']
     lin_protocol = _require_key(node, 'lin_protocol', f"Node {name} has no LIN protocol version specified.")
     slave = LinSlave(name)
-    slave.lin_protocol = lin_protocol
+    slave.lin_protocol = parse_lin_version(lin_protocol)
     slave.configured_nad = _require_key(node, 'configured_nad', f"Node {name} has no configured NAD.")
     slave.initial_nad = slave.configured_nad if node.get('initial_nad') is None else node.get('initial_nad')
 

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -9,7 +9,7 @@ from .schedule import AssignFrameIdEntry, AssignFrameIdRangeEntry, AssignNadEntr
 from .frame import LinEventTriggeredFrame, LinSporadicFrame, LinUnconditionalFrame
 from .signal import LinSignal
 from .encoding import ASCIIValue, BCDValue, LinSignalEncodingType, LogicalValue, PhysicalValue, ValueConverter
-from .lin import LIN_VERSION_2_0, LIN_VERSION_2_1, LinVersion, Iso17987Version, parse_lin_version
+from .lin import LIN_VERSION_2_0, LIN_VERSION_2_1, parse_lin_version
 from .node import LinMaster, LinProductId, LinSlave
 from .ldf import LDF
 from .grammar import LdfTransformer

--- a/ldfparser/templates/ldf.jinja2
+++ b/ldfparser/templates/ldf.jinja2
@@ -18,7 +18,7 @@ Nodes {
     {%- endif %}
 }
 
-{%- if ldf.get_language_version().major == 2 %}
+{%- if ldf.get_language_version().major == 2 or "Iso17987Version" in ldf.get_language_version().__class__.__name__ %}
 Node_attributes {
     {%- for slave in ldf.get_slaves() %}
     {{slave.name}} {

--- a/tests/ldf/iso17987.ldf
+++ b/tests/ldf/iso17987.ldf
@@ -1,0 +1,205 @@
+/*************************************************************************************/
+//                                                                                     
+// Description: LIN Description file created using Vector's DaVinci Network Designer   
+// Created:     04 Feb 2009 15:10:34
+// Version:     0.2                                                                    
+//                                                                                     
+/*************************************************************************************/
+
+LIN_description_file;
+LIN_protocol_version = "ISO17987:2015";
+LIN_language_version = "ISO17987:2015";
+LIN_speed = 19.2 kbps;
+LDF_file_revision = "14.23.01";
+LIN_sig_byte_order_big_endian;
+
+Nodes {
+  Master: VectorMasterNode, 1 ms, 0.1 ms ;
+  Slaves: VectorSlave_ISO, VectorSlave2_0 ;
+}
+
+
+Signals {
+  MotorLinError: 1, 0, VectorSlave_ISO, VectorMasterNode ;
+  MotorLinError_2: 1, 0, VectorSlave2_0, VectorMasterNode ;
+  MotorTemp: 8, 0, VectorSlave_ISO, VectorMasterNode ;
+  MotorTemp_2: 8, 0, VectorSlave2_0, VectorMasterNode ;
+  sig_MotorQuery1: 40, {5, 4, 3, 2, 1}, VectorMasterNode, VectorSlave_ISO ;
+  sig_MotorQuery1_2: 8, 5, VectorMasterNode, VectorSlave2_0 ;
+  sigMotorState1: 8, 0, VectorSlave_ISO, VectorMasterNode ;
+  sigMotorState1_2: 8, 0, VectorSlave2_0, VectorMasterNode ;
+  signal1: 16, 16, VectorMasterNode, VectorSlave_ISO ;
+  signal1_2: 16, 16, VectorMasterNode, VectorSlave2_0 ;
+}
+
+Diagnostic_signals {
+  MasterReqB0: 8, 0 ;
+  MasterReqB1: 8, 0 ;
+  MasterReqB2: 8, 0 ;
+  MasterReqB3: 8, 0 ;
+  MasterReqB4: 8, 0 ;
+  MasterReqB5: 8, 0 ;
+  MasterReqB6: 8, 0 ;
+  MasterReqB7: 8, 0 ;
+  SlaveRespB0: 8, 0 ;
+  SlaveRespB1: 8, 0 ;
+  SlaveRespB2: 8, 0 ;
+  SlaveRespB3: 8, 0 ;
+  SlaveRespB4: 8, 0 ;
+  SlaveRespB5: 8, 0 ;
+  SlaveRespB6: 8, 0 ;
+  SlaveRespB7: 8, 0 ;
+}
+
+
+
+Frames {
+  MotorControl: 4, VectorMasterNode, 2 {
+    signal1, 0 ;
+  }
+  MotorControl_2: 6, VectorMasterNode, 2 {
+    signal1_2, 0 ;
+  }
+  MotorQuery: 5, VectorMasterNode, 5 {
+    sig_MotorQuery1, 0 ;
+  }
+  MotorQuery_2: 7, VectorMasterNode, 1 {
+    sig_MotorQuery1_2, 0 ;
+  }
+  MotorState_Cycl: 0, VectorSlave_ISO, 6 {
+    MotorTemp, 8 ;
+    MotorLinError, 40 ;
+  }
+  MotorState_Cycl_2: 1, VectorSlave2_0, 6 {
+    MotorTemp_2, 8 ;
+    MotorLinError_2, 40 ;
+  }
+  MotorState_Event: 2, VectorSlave_ISO, 3 {
+    sigMotorState1, 8 ;
+  }
+  MotorState_Event_2: 3, VectorSlave2_0, 3 {
+    sigMotorState1_2, 8 ;
+  }
+}
+
+
+Event_triggered_frames {
+  ETF_MotorState_Cycl: CollisionResolver1, 55, MotorState_Cycl, MotorState_Cycl_2 ;
+  ETF_MotorState_Event: CollisionResolver2, 56, MotorState_Event, MotorState_Event_2 ;
+}
+
+Diagnostic_frames {
+  MasterReq: 0x3c {
+    MasterReqB0, 0 ;
+    MasterReqB1, 8 ;
+    MasterReqB2, 16 ;
+    MasterReqB3, 24 ;
+    MasterReqB4, 32 ;
+    MasterReqB5, 40 ;
+    MasterReqB6, 48 ;
+    MasterReqB7, 56 ;
+  }
+  SlaveResp: 0x3d {
+    SlaveRespB0, 0 ;
+    SlaveRespB1, 8 ;
+    SlaveRespB2, 16 ;
+    SlaveRespB3, 24 ;
+    SlaveRespB4, 32 ;
+    SlaveRespB5, 40 ;
+    SlaveRespB6, 48 ;
+    SlaveRespB7, 56 ;
+  }
+}
+
+Node_attributes {
+  VectorSlave_ISO{
+    LIN_protocol = "ISO17987:2015" ;
+    configured_NAD = 0x5 ;
+    initial_NAD = 0x5 ;
+    product_id = 0x1e, 0x2, 1 ;
+    response_error = MotorLinError ;
+    P2_min = 50 ms ;
+    ST_min = 0 ms ;
+    configurable_frames {
+      MotorControl;
+      MotorQuery;
+      MotorState_Cycl;
+      MotorState_Event;
+      ETF_MotorState_Cycl;
+      ETF_MotorState_Event;
+    }
+  }
+  VectorSlave2_0{
+    LIN_protocol = "2.0" ;
+    configured_NAD = 0x1 ;
+    product_id = 0x1e, 0x1, 0 ;
+    response_error = MotorLinError_2 ;
+    P2_min = 50 ms ;
+    ST_min = 0 ms ;
+    configurable_frames {
+      MotorControl_2 = 0x1234 ;
+      MotorQuery_2 = 0x1999 ;
+      MotorState_Cycl_2 = 0x2222 ;
+      MotorState_Event_2 = 0x2333 ;
+      ETF_MotorState_Event = 0x4444 ;
+      ETF_MotorState_Cycl = 0x4567 ;
+    }
+  }
+}
+
+Schedule_tables {
+ InitTable {
+    MotorQuery delay 7 ms ;
+    MotorQuery_2 delay 7 ms ;
+    MotorControl_2 delay 10 ms ;
+    MotorControl delay 10 ms ;
+    MotorState_Cycl delay 10 ms ;
+    MotorState_Cycl_2 delay 10 ms ;
+    MotorState_Event delay 6 ms ;
+    MotorState_Event_2 delay 6 ms ;
+  }
+ ETF_Table {
+    ETF_MotorState_Cycl delay 20 ms ;
+    ETF_MotorState_Event delay 20 ms ;
+  }
+ CollisionResolver1 {
+    MotorState_Cycl delay 10 ms ;
+    MotorState_Cycl_2 delay 10 ms ;
+  }
+ CollisionResolver2 {
+    MotorState_Event delay 10 ms ;
+    MotorState_Event_2 delay 10 ms ;
+  }
+ Table4 {
+    AssignNAD { VectorSlave_ISO } delay 10 ms ;
+    SlaveResp delay 10 ms ;
+  }
+}
+
+Signal_encoding_types {
+  encError {
+    logical_value, 0, "No Error" ;
+    logical_value, 1, "Response Error" ;
+  }
+  encoding1 {
+    physical_value, 0, 200, 1.000, 0.000, "temperature" ;
+    logical_value, 255, "invalid" ;
+  }
+  encState {
+    physical_value, 0, 200, 0.500, -20.000, "" ;
+  }
+  encTemperature {
+    physical_value, 0, 200, 0.500, -20.000, "Degree" ;
+  }
+}
+
+Signal_representation {
+  encError: MotorLinError ;
+  encoding1: signal1 ;
+  encState: sigMotorState1 ;
+  encTemperature: MotorTemp ;
+}
+
+
+
+

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 import pytest
-from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2
+from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, Iso17987Version
 
 @pytest.mark.unit()
 @pytest.mark.parametrize(
@@ -114,3 +114,22 @@ def test_linversion_float(version, expected):
 def test_linversion_typerror(func, arg):
     with pytest.raises(TypeError):
         func(arg)
+
+@pytest.mark.unit()
+@pytest.mark.parametrize(
+    ('a', 'b', 'op', 'result'),
+    [
+        (Iso17987Version(2015), Iso17987Version(2015), Iso17987Version.__eq__, True),
+        (Iso17987Version(2015), Iso17987Version(2016), Iso17987Version.__eq__, False),
+        (Iso17987Version(2015), Iso17987Version(2015), Iso17987Version.__ne__, False),
+        (Iso17987Version(2015), Iso17987Version(2016), Iso17987Version.__ne__, True),
+        (Iso17987Version(2015), Iso17987Version(2016), Iso17987Version.__gt__, False),
+        (Iso17987Version(2015), LIN_VERSION_2_0, Iso17987Version.__gt__, True),
+        (Iso17987Version(2015), Iso17987Version(2015), Iso17987Version.__ge__, True),
+        (Iso17987Version(2015), Iso17987Version(2016), Iso17987Version.__lt__, True),
+        (Iso17987Version(2015), LIN_VERSION_2_0, Iso17987Version.__lt__, False),
+        (Iso17987Version(2015), Iso17987Version(2015), Iso17987Version.__le__, True)
+    ]
+)
+def test_linversion_iso_compare(a, b, op, result):
+    assert op(a, b) == result

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 import pytest
-from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, Iso17987Version
+from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, Iso17987Version, parse_lin_version
 
 @pytest.mark.unit()
 @pytest.mark.parametrize(
@@ -133,3 +133,26 @@ def test_linversion_typerror(func, arg):
 )
 def test_linversion_iso_compare(a, b, op, result):
     assert op(a, b) == result
+
+@pytest.mark.parametrize(
+    ('a', 'b', 'op', 'exc'),
+    [
+        (Iso17987Version(2015), 2015, Iso17987Version.__gt__, TypeError),
+        (Iso17987Version(2015), 2015, Iso17987Version.__lt__, TypeError)
+    ]
+)
+def test_linversion_iso_invalid(a, b, op, exc):
+    with pytest.raises(exc):
+        op(a, b)
+
+@pytest.mark.parametrize(
+    ('value'),
+    [
+        '',
+        '2.1.2',
+        'ISO17987:abc'
+    ]
+)
+def test_linversion_parse_invalid(value):
+    with pytest.raises(ValueError):
+        parse_lin_version(value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,7 +6,7 @@ from ldfparser.parser import parse_ldf
 from ldfparser.frame import LinFrame
 from ldfparser.signal import LinSignal
 from ldfparser.encoding import ASCIIValue, BCDValue, LogicalValue
-
+from ldfparser.lin import Iso17987Version
 
 @pytest.mark.unit
 def test_load_valid_lin13():
@@ -200,3 +200,14 @@ def test_load_sporadic_frames():
 
     with pytest.raises(LookupError):
         ldf.get_frame('SF_123')
+
+@pytest.mark.unit
+def test_load_iso17987():
+    path = os.path.join(os.path.dirname(__file__), "ldf", "iso17987.ldf")
+    ldf = parse_ldf(path)
+
+    assert isinstance(ldf.get_protocol_version(), Iso17987Version)
+    assert ldf.get_protocol_version().revision == 2015
+
+    assert isinstance(ldf.get_language_version(), Iso17987Version)
+    assert ldf.get_language_version().revision == 2015


### PR DESCRIPTION
## Brief

- Grammar supports file revision, endianness and ISO versions.
- Version is read into the LDF object

### Checklist

- [x] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [x] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [ ] Update version number

## Resolves

+ Resolves #111 

## Evidence

+ Protocol and language version can now return different types, but it's going to be evident when users have to account for this
