### PR TITLE
Returning diag. frames and removing deprecated func. call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2023-03-12
+
 ### Added
 
 - ISO17987 version support
@@ -14,9 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `LDF_file_revision`
   - Endianness
 
+### Changed
+
+- `LDF::get_frame` can now return diagnostic frames
+
 ### Fixes
 
 - `LinSlave` protocol version property is now the correct type
+- `LinUnconditionalFrame::decode` no longer calls the deprecated `parse_raw` function
 
 ## [0.18.0] - 2022-12-13
 

--- a/ldfparser/frame.py
+++ b/ldfparser/frame.py
@@ -206,7 +206,7 @@ class LinUnconditionalFrame(LinFrame):
             frame_layout = u6p2u8u1u1p6
 
         """
-        parsed = self.parse_raw(data)
+        parsed = self.decode_raw(data)
         converted = {}
         for (signal_name, value) in parsed.items():
             signal = self._get_signal(signal_name)

--- a/ldfparser/ldf.py
+++ b/ldfparser/ldf.py
@@ -98,7 +98,7 @@ class LDF():
             pass
         try:
             return self.get_sporadic_frame(frame_id)
-        except LookupError as exc:
+        except LookupError:
             pass
         try:
             return self.get_diagnostic_frame(frame_id)

--- a/ldfparser/ldf.py
+++ b/ldfparser/ldf.py
@@ -87,7 +87,7 @@ class LDF():
         """
         return self._slaves.values()
 
-    def get_frame(self, frame_id: Union[int, str]) -> Union[LinUnconditionalFrame, LinEventTriggeredFrame, LinSporadicFrame]:
+    def get_frame(self, frame_id: Union[int, str]) -> Union[LinUnconditionalFrame, LinEventTriggeredFrame, LinSporadicFrame, LinDiagnosticFrame]:
         try:
             return self.get_unconditional_frame(frame_id)
         except LookupError:
@@ -98,6 +98,10 @@ class LDF():
             pass
         try:
             return self.get_sporadic_frame(frame_id)
+        except LookupError as exc:
+            pass
+        try:
+            return self.get_diagnostic_frame(frame_id)
         except LookupError as exc:
             raise exc
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.18.0
+version = 0.19.0


### PR DESCRIPTION
## Brief

- `LinUnconditionalFrame::decode` no longer calls the deprecated `parse_raw` function
- `LDF::get_frame` can now return diagnostic frames

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [x] Review test results and code coverage
  - [x] Review snapshot test results for deviations
- [x] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [x] Update version number

## Evidence

+ Deprecated function already called the correct one
+ Users of the `get_frame` function already had to account for the possibility of it returning different types
