### PR TITLE
Add support for protocol version J2602_1_1.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W191,E501,E302,E305
+ignore = W504,W191,E501,E302,E305
 exclude = 
     .git
     __pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.20.0] - 2023-06-09
+## [0.20.0] - 2023-06-12
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2023-06-09
+
+### Added
+
+- Support for SAE J2602 legacy version
+- Grammar support for the following J2602 fields:
+  - `max_header_length`, `response_tolerance` for the master node
+  - `response_tolerance` for slave node attributes
+
 ## [0.19.0] - 2023-03-12
 
 ### Added

--- a/ldfparser/grammar.py
+++ b/ldfparser/grammar.py
@@ -72,7 +72,7 @@ class LdfTransformer(Transformer):
         return ("nodes", {'master': tree[0], 'slaves': tree[1]})
 
     def nodes_master(self, tree):
-        return {"name": tree[0], "timebase": tree[1] * 0.001, "jitter": tree[2] * 0.001}
+        return {"name": tree[0], "timebase": tree[1] * 0.001, "jitter": tree[2] * 0.001, "max_header_length": tree[3] if len(tree) > 3 else None, "response_tolerance": tree[4] * 0.01 if len(tree) > 4 else None}
 
     def nodes_slaves(self, tree):
         return tree
@@ -200,6 +200,9 @@ class LdfTransformer(Transformer):
 
     def node_definition_configurable_frames_21(self, tree):
         return ("configurable_frames", tree[0:])
+
+    def node_definition_response_tolerance(self, tree):
+        return ("response_tolerance", tree[0] * 0.01)
 
     def schedule_tables(self, tree):
         return ("schedule_tables", tree)

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -23,7 +23,7 @@ header_sig_byte_order_little_endian: "LIN_sig_byte_order_little_endian" ";"
 // LIN 2.1 Specification, section 9.2.2
 // SAE J2602-3_201001, SECTION 7.2
 nodes: "Nodes" "{" nodes_master? nodes_slaves? "}"
-nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ("," ldf_integer "bits" "," ldf_float "%")* ";"
+nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ("," ldf_integer "bits" "," ldf_float "%")? ";"
 nodes_slaves: "Slaves" ":" ldf_identifier ("," ldf_identifier)* ";"
 
 // LIN 2.1 Specification, section 9.2.2.3

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -3,7 +3,7 @@ start: ldf
 ldf: (header_lin_description_file | header_protocol_version | header_language_version | header_speed | header_channel | header_file_revision | header_sig_byte_order_big_endian | header_sig_byte_order_little_endian | nodes | node_compositions | signals | diagnostic_signals | diagnostic_addresses | frames | sporadic_frames | event_triggered_frames | diagnostic_frames | node_attributes | schedule_tables | signal_groups | signal_encoding_types | signal_representations)*
 
 ldf_identifier: CNAME
-ldf_version: LIN_VERSION | ISO_VERSION
+ldf_version: LIN_VERSION | ISO_VERSION | J2602_VERSION
 ldf_integer: C_INT
 ldf_float: C_FLOAT
 ldf_channel_name: ESCAPED_STRING
@@ -21,8 +21,9 @@ header_sig_byte_order_big_endian: "LIN_sig_byte_order_big_endian" ";"
 header_sig_byte_order_little_endian: "LIN_sig_byte_order_little_endian" ";"
 
 // LIN 2.1 Specification, section 9.2.2
+// SAE J2602-3_201001, SECTION 7.2
 nodes: "Nodes" "{" nodes_master? nodes_slaves? "}"
-nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ";"
+nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ("," ldf_integer "bits" "," ldf_float "%")* ";"
 nodes_slaves: "Slaves" ":" ldf_identifier ("," ldf_identifier)* ";"
 
 // LIN 2.1 Specification, section 9.2.2.3
@@ -66,8 +67,9 @@ diagnostic_addresses: "Diagnostic_addresses" "{" (diagnostic_address)* "}"
 diagnostic_address: ldf_identifier ":" ldf_integer ";"
 
 // LIN 2.1 Specification, section 9.2.2.2
+// response_tolerance: SAE J2602_1_201001, section 7.2.1
 node_attributes: "Node_attributes" "{" (node_definition*) "}"
-node_definition: ldf_identifier "{" (node_definition_protocol | node_definition_configured_nad | node_definition_initial_nad | node_definition_product_id | node_definition_response_error | node_definition_fault_state_signals | node_definition_p2_min | node_definition_st_min | node_definition_n_as_timeout | node_definition_n_cr_timeout | node_definition_configurable_frames)* "}"
+node_definition: ldf_identifier "{" (node_definition_protocol | node_definition_configured_nad | node_definition_initial_nad | node_definition_product_id | node_definition_response_error | node_definition_fault_state_signals | node_definition_p2_min | node_definition_st_min | node_definition_n_as_timeout | node_definition_n_cr_timeout | node_definition_configurable_frames | node_definition_response_tolerance)* "}"
 node_definition_protocol: "LIN_protocol" "=" (["\"" ldf_version "\""] | ldf_version) ";"
 node_definition_configured_nad: "configured_NAD" "=" ldf_integer ";"
 node_definition_initial_nad: "initial_NAD" "=" ldf_integer ";"
@@ -81,6 +83,8 @@ node_definition_n_cr_timeout: "N_Cr_timeout" "=" ldf_float "ms" ";"
 node_definition_configurable_frames: node_definition_configurable_frames_20 | node_definition_configurable_frames_21
 node_definition_configurable_frames_20: "configurable_frames" "{" (ldf_identifier "=" ldf_integer ";")+ "}"
 node_definition_configurable_frames_21: "configurable_frames" "{" (ldf_identifier ";")+ "}"
+node_definition_response_tolerance: "response_tolerance" "=" ldf_float "%" ";"
+
 
 // LIN 2.1 Specification, section 9.2.5
 schedule_tables: "Schedule_tables" "{" (schedule_table_definition+) "}" 
@@ -120,6 +124,7 @@ C_INT: ("0x"HEXDIGIT+) | ("-"? INT)
 C_FLOAT: ("-"? INT ("." INT)?) ("e" ("+" | "-")? INT)?
 LIN_VERSION: INT "." INT
 ISO_VERSION: "ISO17987" ":" INT
+J2602_VERSION: "J2602" "_" INT "_" INT "." INT
 
 ANY_SEMICOLON_TERMINATED_LINE: /.*;/
 

--- a/ldfparser/ldf.py
+++ b/ldfparser/ldf.py
@@ -3,7 +3,7 @@ Lin Description File handler objects
 """
 from typing import Union, Dict, List
 
-from .lin import LinVersion, Iso17987Version
+from .lin import LinVersion, Iso17987Version, J2602Version
 from .frame import LinFrame, LinSporadicFrame, LinUnconditionalFrame, LinEventTriggeredFrame
 from .diagnostics import LinDiagnosticFrame, LinDiagnosticRequest, LinDiagnosticResponse
 from .signal import LinSignal
@@ -19,8 +19,8 @@ class LDF():
 
     def __init__(self):
         self._source: Dict = None
-        self._protocol_version: Union[LinVersion, Iso17987Version] = None
-        self._language_version: Union[LinVersion, Iso17987Version] = None
+        self._protocol_version: Union[LinVersion, Iso17987Version, J2602Version] = None
+        self._language_version: Union[LinVersion, Iso17987Version, J2602Version] = None
         self._baudrate: int = None
         self._channel: str = None
         self._master: LinMaster = None
@@ -38,11 +38,11 @@ class LDF():
         self._schedule_tables: Dict[str, ScheduleTable] = {}
         self._comments: List[str] = []
 
-    def get_protocol_version(self) -> Union[LinVersion, Iso17987Version]:
+    def get_protocol_version(self) -> Union[LinVersion, Iso17987Version, J2602Version]:
         """Returns the protocol version of the LIN network"""
         return self._protocol_version
 
-    def get_language_version(self) -> Union[LinVersion, Iso17987Version]:
+    def get_language_version(self) -> Union[LinVersion, Iso17987Version, J2602Version]:
         """Returns the LDF language version"""
         return self._language_version
 

--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -3,14 +3,16 @@ Utility classes for LIN objects
 """
 from typing import Union
 
+
 class LinVersion:
     """
     LinVersion represents the LIN protocol and LDF language versions
     """
 
-    def __init__(self, major: int, minor: int) -> None:
+    def __init__(self, major: int, minor: int, use_j2602=False) -> None:
         self.major = major
         self.minor = minor
+        self.use_j2602 = use_j2602
 
     @staticmethod
     def from_string(version: str) -> 'LinVersion':
@@ -76,8 +78,9 @@ LIN_VERSION_2_2 = LinVersion(2, 2)
 
 class Iso17987Version:
 
-    def __init__(self, revision: int) -> None:
+    def __init__(self, revision: int, use_j2602: bool = False) -> None:
         self.revision = revision
+        self.use_j2602 = use_j2602
 
     @staticmethod
     def from_string(version: str) -> 'Iso17987Version':
@@ -118,6 +121,30 @@ class Iso17987Version:
 
 ISO17987_2015 = Iso17987Version(2015)
 
+def parse_j2602_version(version: str) -> Union[LinVersion, Iso17987Version]:
+    """
+    Return the version object from J2602 version string.
+
+    According to J2602-3_202110, section 7.1.3:
+    “J2602_1_1.0” -> J2602:2012 and earlier -> based on LIN 2.0
+    “J2602_1_2.0” -> J2602:2021 -> based on ISO 17987:2016
+
+    Therefore,
+    “J2602_1_1.0” -> LinVersion(2, 0)
+
+    Support for J2602_1_2.0 is not implemented at this time.
+    """
+    if "J2602" not in version:
+        raise ValueError(f'{version} is not an SAE J2602 version.')
+
+    version = version.replace("J2602_", '')
+    (_, versions) = version.split('_')
+    major = int(versions.split('.')[0])
+    if major == 1:
+        return LinVersion(major=2, minor=0, use_j2602=True)
+
+    raise ValueError(f'{version} is not supported yet.')
+
 def parse_lin_version(version: str) -> Union[LinVersion, Iso17987Version]:
     try:
         return LinVersion.from_string(version)
@@ -125,4 +152,6 @@ def parse_lin_version(version: str) -> Union[LinVersion, Iso17987Version]:
         try:
             return Iso17987Version.from_string(version)
         except ValueError:
+            if "J2602" in version:
+                return parse_j2602_version(version)
             raise ValueError(f'{version} is not a valid LIN version.')

--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -9,10 +9,9 @@ class LinVersion:
     LinVersion represents the LIN protocol and LDF language versions
     """
 
-    def __init__(self, major: int, minor: int, use_j2602=False) -> None:
+    def __init__(self, major: int, minor: int) -> None:
         self.major = major
         self.minor = minor
-        self.use_j2602 = use_j2602
 
     @staticmethod
     def from_string(version: str) -> 'LinVersion':
@@ -84,9 +83,8 @@ LIN_VERSION_2_2 = LinVersion(2, 2)
 
 class Iso17987Version:
 
-    def __init__(self, revision: int, use_j2602: bool = False) -> None:
+    def __init__(self, revision: int) -> None:
         self.revision = revision
-        self.use_j2602 = use_j2602
 
     @staticmethod
     def from_string(version: str) -> 'Iso17987Version':

--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -227,4 +227,3 @@ def parse_lin_version(version: str) -> Union[LinVersion, Iso17987Version, J2602V
             pass
 
     raise ValueError(f'{version} is not a valid LIN version.')
-

--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -42,6 +42,8 @@ class LinVersion:
     def __eq__(self, o: object) -> bool:
         if isinstance(o, LinVersion):
             return self.major == o.major and self.minor == o.minor
+        elif isinstance(o, J2602Version):
+            return self.major == 2 and self.minor == 0
         return False
 
     def __gt__(self, o) -> bool:
@@ -51,6 +53,8 @@ class LinVersion:
             if self.major == o.major and self.minor > o.minor:
                 return True
             return False
+        elif isinstance(o, J2602Version):
+            return (self.major == 2 and self.minor > 0) or self.major > 2
         raise TypeError()
 
     def __lt__(self, o) -> bool:
@@ -60,6 +64,8 @@ class LinVersion:
             if self.major == o.major and self.minor < o.minor:
                 return True
             return False
+        elif isinstance(o, J2602Version):
+            return self.major < 2
         raise TypeError()
 
     def __ge__(self, o) -> bool:
@@ -121,37 +127,104 @@ class Iso17987Version:
 
 ISO17987_2015 = Iso17987Version(2015)
 
-def parse_j2602_version(version: str) -> Union[LinVersion, Iso17987Version]:
-    """
-    Return the version object from J2602 version string.
+class J2602Version:
+    def __init__(self, major, minor, part):
+        """
+        Abstract the J2602 version.
+        """
+        self.major = major
+        self.minor = minor
+        self.part = part
 
-    According to J2602-3_202110, section 7.1.3:
-    “J2602_1_1.0” -> J2602:2012 and earlier -> based on LIN 2.0
-    “J2602_1_2.0” -> J2602:2021 -> based on ISO 17987:2016
+    @staticmethod
+    def from_string(version: str) -> 'J2602Version':
+        """
+        Create an instance from the version string.
 
-    Therefore,
-    “J2602_1_1.0” -> LinVersion(2, 0)
+        The version string J2602_1_2.0 will render:
+            major=2, minor=0, part=1
 
-    Support for J2602_1_2.0 is not implemented at this time.
-    """
-    if "J2602" not in version:
-        raise ValueError(f'{version} is not an SAE J2602 version.')
+        Support for J2602_1_2.0 is not implemented at this time.
+        """
+        if "J2602" not in version:
+            raise ValueError(f'{version} is not an SAE J2602 version.')
 
-    version = version.replace("J2602_", '')
-    (_, versions) = version.split('_')
-    major = int(versions.split('.')[0])
-    if major == 1:
-        return LinVersion(major=2, minor=0, use_j2602=True)
+        version = version.replace("J2602_", '')
+        (part, versions) = version.split('_')
+        major, minor = [int(value) for value in versions.split('.')]
+        if major == 1:
+            return J2602Version(major=major, minor=minor, part=int(part))
 
-    raise ValueError(f'{version} is not supported yet.')
+        raise ValueError(f'{version} is not supported yet.')
 
-def parse_lin_version(version: str) -> Union[LinVersion, Iso17987Version]:
-    try:
-        return LinVersion.from_string(version)
-    except ValueError:
+    def __str__(self) -> str:
+        return f"J2602_{self.part}_{self.major}.{self.minor}"
+
+    def __eq__(self, o: object) -> bool:
+        """
+        According to J2602-3_202110, section 7.1.3:
+        “J2602_1_1.0” -> J2602:2012 and earlier -> based on LIN 2.0
+        “J2602_1_2.0” -> J2602:2021 -> based on ISO 17987:2016
+
+        Therefore,
+        “J2602_1_1.0” is considered equal to LinVersion(2, 0)
+
+        """
+        if isinstance(o, J2602Version):
+            return (
+                self.major == o.major and
+                self.minor == o.minor and
+                self.part == o.part
+            )
+        elif isinstance(o, Iso17987Version):
+            return False
+        elif isinstance(o, LinVersion):
+            return o == LIN_VERSION_2_0
+        return False
+
+    def __gt__(self, o) -> bool:
+        if isinstance(o, J2602Version):
+            return (
+                self.major > o.major or
+                (
+                    self.major == o.major and self.minor > o.minor
+                )
+            )
+        if isinstance(o, Iso17987Version):
+            return False
+        if isinstance(o, LinVersion):
+            return o < LIN_VERSION_2_0
+        raise TypeError()
+
+    def __lt__(self, o) -> bool:
+        if isinstance(o, J2602Version):
+            return (
+                self.major < o.major or
+                (
+                    self.major == o.major and self.minor < o.minor
+                )
+            )
+        if isinstance(o, Iso17987Version):
+            return True
+        if isinstance(o, LinVersion):
+            return o > LIN_VERSION_2_0
+        raise TypeError()
+
+    def __ge__(self, o) -> bool:
+        return not self.__lt__(o)
+
+    def __le__(self, o) -> bool:
+        return not self.__gt__(o)
+
+    def __ne__(self, o: object) -> bool:
+        return not self.__eq__(o)
+
+def parse_lin_version(version: str) -> Union[LinVersion, Iso17987Version, J2602Version]:
+    for version_class in [LinVersion, Iso17987Version, J2602Version]:
         try:
-            return Iso17987Version.from_string(version)
-        except ValueError:
-            if "J2602" in version:
-                return parse_j2602_version(version)
-            raise ValueError(f'{version} is not a valid LIN version.')
+            return version_class.from_string(version)
+        except (ValueError, IndexError):
+            pass
+
+    raise ValueError(f'{version} is not a valid LIN version.')
+

--- a/ldfparser/node.py
+++ b/ldfparser/node.py
@@ -78,10 +78,20 @@ class LinMaster(LinNode):
     :type jitter: float
     """
 
-    def __init__(self, name: str, timebase: float, jitter: float):
+    def __init__(
+            self,
+            name: str,
+            timebase: float,
+            jitter: float,
+            max_header_length: int,
+            response_tolerance: float,
+    ):
         super().__init__(name)
         self.timebase: float = timebase
         self.jitter: float = jitter
+        self.max_header_length: int = max_header_length
+        self.response_tolerance: float = response_tolerance
+
 
 class LinSlave(LinNode):
     """
@@ -124,6 +134,7 @@ class LinSlave(LinNode):
         self.n_as_timeout: float = 1
         self.n_cr_timeout: float = 1
         self.configurable_frames = {}
+        self.response_tolerance = None
 
 class LinNodeCompositionConfiguration:
 

--- a/ldfparser/node.py
+++ b/ldfparser/node.py
@@ -6,7 +6,7 @@ from typing import List, TYPE_CHECKING, Union
 if TYPE_CHECKING:
     from .frame import LinFrame
     from .signal import LinSignal
-    from .lin import LinVersion, Iso17987Version
+    from .lin import LinVersion, Iso17987Version, J2602Version
 
 LIN_SUPPLIER_ID_WILDCARD = 0x7FFF
 LIN_FUNCTION_ID_WILDCARD = 0xFFFF
@@ -76,6 +76,11 @@ class LinMaster(LinNode):
     :type timebase: float
     :param jitter: LIN network jitter in seconds
     :type jitter: float
+    :param max_header_length: The maximum number of bits of the header length
+    :type max_header_length: int
+    :param response_tolerance: The value between 0.0 - 1.0 that represents the
+        percentage of the frame response tolerance.
+    :type response_tolerance: float
     """
 
     def __init__(
@@ -119,11 +124,14 @@ class LinSlave(LinNode):
     :type n_cr_timeout:
     :param configurable_frames:
     :type configurable_frames:
+    :param response_tolerance: The value between 0.0 - 1.0 that represents the
+        percentage of the frame response tolerance. For example, 0.4 for 40%.
+    :type response_tolerance: float
     """
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
-        self.lin_protocol: Union[LinVersion, Iso17987Version] = None
+        self.lin_protocol: Union[LinVersion, Iso17987Version, J2602Version] = None
         self.configured_nad: int = None
         self.initial_nad: int = None
         self.product_id: LinProductId = None
@@ -134,7 +142,7 @@ class LinSlave(LinNode):
         self.n_as_timeout: float = 1
         self.n_cr_timeout: float = 1
         self.configurable_frames = {}
-        self.response_tolerance = None
+        self.response_tolerance: float = None
 
 class LinNodeCompositionConfiguration:
 

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -9,7 +9,7 @@ from .schedule import AssignFrameIdEntry, AssignFrameIdRangeEntry, AssignNadEntr
 from .frame import LinEventTriggeredFrame, LinSporadicFrame, LinUnconditionalFrame
 from .signal import LinSignal
 from .encoding import ASCIIValue, BCDValue, LinSignalEncodingType, LogicalValue, PhysicalValue, ValueConverter
-from .lin import LIN_VERSION_2_0, LIN_VERSION_2_1, parse_lin_version
+from .lin import LIN_VERSION_2_0, LIN_VERSION_2_1, J2602Version, parse_lin_version
 from .node import LinMaster, LinProductId, LinSlave
 from .ldf import LDF
 from .grammar import LdfTransformer
@@ -151,13 +151,13 @@ def _populate_ldf_nodes(json: dict, ldf: LDF):
 
     if nodes.get('master'):
         master_node = nodes['master']
-        is_j2602_protocol = ldf.get_protocol_version().use_j2602
-        default_max_header_length = 48 if is_j2602_protocol else None
-        default_response_tolerance = 0.4 if is_j2602_protocol else None
+        is_j2602_protocol = isinstance(ldf.get_protocol_version(), J2602Version)
+        default_max_header_len = 48 if is_j2602_protocol else None
+        default_resp_tolerance = 0.4 if is_j2602_protocol else None
         if master_node['max_header_length'] is None:
-            master_node['max_header_length'] = default_max_header_length
+            master_node['max_header_length'] = default_max_header_len
         if master_node['response_tolerance'] is None:
-            master_node['response_tolerance'] = default_response_tolerance
+            master_node['response_tolerance'] = default_resp_tolerance
         ldf._master = LinMaster(**master_node)
 
     if nodes.get('slaves'):
@@ -196,8 +196,9 @@ def _create_ldf2x_node(node: dict, language_version: float):
     slave.st_min = node.get('ST_min', 0)
     slave.n_as_timeout = node.get('N_As_timeout', 1)
     slave.n_cr_timeout = node.get('N_Cr_timeout', 1)
-    default_response_tolerance = 0.4 if slave.lin_protocol.use_j2602 else None
-    slave.response_tolerance = node.get('response_tolerance', default_response_tolerance)
+    is_j2602_protocol = isinstance(slave.lin_protocol, J2602Version)
+    default_resp_tolerance = 0.4 if is_j2602_protocol else None
+    slave.response_tolerance = node.get('response_tolerance', default_resp_tolerance)
 
     return slave
 

--- a/ldfparser/templates/ldf.jinja2
+++ b/ldfparser/templates/ldf.jinja2
@@ -11,14 +11,14 @@ Channel_name = "{{ ldf.get_channel() }}";
 
 Nodes {
     {%- if ldf.get_master() %}
-    Master: {{ ldf.get_master().name }}, {{ ldf.get_master().timebase * 1000 | float}} ms, {{ ldf.get_master().jitter * 1000 }} ms;
+    Master: {{ ldf.get_master().name }}, {{ ldf.get_master().timebase * 1000 | float}} ms, {{ ldf.get_master().jitter * 1000 }} ms{%- if ldf.get_master().max_header_length is not none %}, {{ldf.get_master().max_header_length}} bits{%- endif %}{%- if ldf.get_master().response_tolerance is not none %}, {{ldf.get_master().response_tolerance * 100}} %{%- endif %};
     {%- endif %}
     {%- if ldf.get_slaves() %}
     Slaves: {%- for slave in ldf.get_slaves() %} {{ slave.name }}{%- if not loop.last %},{% endif -%}{%- endfor -%};
     {%- endif %}
 }
 
-{%- if ldf.get_language_version().major == 2 or "Iso17987Version" in ldf.get_language_version().__class__.__name__ %}
+{%- if ldf.get_language_version().major == 2 or "Iso17987Version" in ldf.get_language_version().__class__.__name__ or "J2602" in ldf.get_language_version().__class__.__name__ %}
 Node_attributes {
     {%- for slave in ldf.get_slaves() %}
     {{slave.name}} {
@@ -44,6 +44,9 @@ Node_attributes {
             {{frame.name}}{% if slave.lin_protocol == "2.0" %} = {{id}}{% endif -%};
             {%- endfor %}
         }
+        {%- endif %}
+        {%- if slave.response_tolerance %}
+        response_tolerance = {{slave.response_tolerance * 100}} %;
         {%- endif %}
     }
     {%- endfor %}

--- a/schemas/ldf.json
+++ b/schemas/ldf.json
@@ -21,6 +21,12 @@
                 },
                 "jitter": {
                     "type": "number"
+                },
+                "max_header_length": {
+                    "type": ["null", "integer"]
+                },
+                "response_tolerance": {
+                    "type": ["null", "number"]
                 }
             },
             "required": [
@@ -288,6 +294,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "response_tolerance": {
+                    "type": ["null", "number"]
                 }
             },
             "required": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.19.0
+version = 0.20.0

--- a/tests/ldf/j2602_1.ldf
+++ b/tests/ldf/j2602_1.ldf
@@ -8,7 +8,7 @@ LIN_language_version = "J2602_3_1.0";
 LIN_speed = 19.2 kbps;
 
 Nodes {
-    Master: CEM, 5 ms, 0.1 ms, 24 bits, 30% ;
+    Master: CEM, 5 ms, 0.1 ms, 24 bits, 30 % ;
     Slaves: LSM;
 }
 

--- a/tests/ldf/j2602_1.ldf
+++ b/tests/ldf/j2602_1.ldf
@@ -1,0 +1,55 @@
+/*
+* Description: The LIN description file for the example program
+*/
+
+LIN_description_file ;
+LIN_protocol_version = "J2602_1_1.0";
+LIN_language_version = "J2602_3_1.0";
+LIN_speed = 19.2 kbps;
+
+Nodes {
+    Master: CEM, 5 ms, 0.1 ms, 24 bits, 30% ;
+    Slaves: LSM;
+}
+
+Signals {
+    InternalLightsRequest: 2, 0, CEM, LSM;
+    InternalLightsSwitch: 2, 0, LSM, CEM;
+}
+
+Frames {
+    VL1_CEM_Frm1: 1, CEM {
+        InternalLightsRequest, 0;
+    }
+    VL1_LSM_Frm1: 2, LSM {
+        InternalLightsSwitch, 0;
+    }
+}
+
+Node_attributes {
+    LSM {
+        LIN_protocol = 2.0;
+        configured_NAD = 0x01;
+		response_tolerance = 38 % ;
+    }
+}
+
+Schedule_tables {
+    MySchedule1 {
+        VL1_CEM_Frm1 delay 15 ms;
+        VL1_LSM_Frm1 delay 15 ms;
+    }
+}
+
+Signal_encoding_types {
+    Dig2Bit {
+        logical_value, 0, "off";
+        logical_value, 1, "on";
+        logical_value, 2, "error";
+        logical_value, 3, "void";
+    }
+}
+
+Signal_representation {
+    Dig2Bit: InternalLightsRequest, InternalLightsSwitch;
+}

--- a/tests/ldf/j2602_1_no_values.ldf
+++ b/tests/ldf/j2602_1_no_values.ldf
@@ -1,0 +1,54 @@
+/*
+* Description: The LIN description file with J2602 protocol version, without the new attributes
+*/
+
+LIN_description_file ;
+LIN_protocol_version = "J2602_1_1.0";
+LIN_language_version = "J2602_3_1.0";
+LIN_speed = 10.417 kbps;
+
+Nodes {
+    Master: CEM, 5 ms, 0.1 ms;
+    Slaves: LSM;
+}
+
+Signals {
+    InternalLightsRequest: 2, 0, CEM, LSM;
+    InternalLightsSwitch: 2, 0, LSM, CEM;
+}
+
+Frames {
+    VL1_CEM_Frm1: 1, CEM {
+        InternalLightsRequest, 0;
+    }
+    VL1_LSM_Frm1: 2, LSM {
+        InternalLightsSwitch, 0;
+    }
+}
+
+Node_attributes {
+    LSM {
+        LIN_protocol = "J2602_1_1.0";
+        configured_NAD = 0x01;
+    }
+}
+
+Schedule_tables {
+    MySchedule1 {
+        VL1_CEM_Frm1 delay 15 ms;
+        VL1_LSM_Frm1 delay 15 ms;
+    }
+}
+
+Signal_encoding_types {
+    Dig2Bit {
+        logical_value, 0, "off";
+        logical_value, 1, "on";
+        logical_value, 2, "error";
+        logical_value, 3, "void";
+    }
+}
+
+Signal_representation {
+    Dig2Bit: InternalLightsRequest, InternalLightsSwitch;
+}

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 import pytest
-from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, Iso17987Version, parse_lin_version
+from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, Iso17987Version, parse_lin_version, parse_j2602_version
 
 @pytest.mark.unit()
 @pytest.mark.parametrize(
@@ -156,3 +156,42 @@ def test_linversion_iso_invalid(a, b, op, exc):
 def test_linversion_parse_invalid(value):
     with pytest.raises(ValueError):
         parse_lin_version(value)
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ('J2602_1_1.0', LIN_VERSION_2_0),
+        ('J2602_3_1.0', LIN_VERSION_2_0),
+        ('J2602_1_1.1', LIN_VERSION_2_0),
+    ]
+)
+def test_linversion_from_j2602(value, expected):
+    result = parse_lin_version(value)
+    assert result.__class__ == expected.__class__
+    assert result == expected
+    assert result.use_j2602
+
+@pytest.mark.parametrize(
+    'value',
+    [
+        '1.1',
+        '2.2',
+    ]
+)
+def test_linversion_j2602_default(value):
+    result = parse_lin_version(value)
+    assert not result.use_j2602
+
+@pytest.mark.parametrize(
+    ('value'),
+    [
+        '',
+        '1.2',
+        'ISO17987:2016',
+        'J2602_1_2.0'
+    ]
+)
+def test_linversion_unsupported_j2602(value):
+    with pytest.raises(ValueError):
+        parse_j2602_version(value)

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -157,7 +157,7 @@ def test_linversion_parse_invalid(value):
     with pytest.raises(ValueError):
         parse_lin_version(value)
 
-
+@pytest.mark.unit()
 @pytest.mark.parametrize(
     ('value', 'expected'),
     [
@@ -171,7 +171,7 @@ def test_linversion_from_j2602(value, expected):
     assert result.__class__ == expected.__class__
     assert result == expected
     assert result.use_j2602
-
+@pytest.mark.unit()
 @pytest.mark.parametrize(
     'value',
     [
@@ -182,7 +182,7 @@ def test_linversion_from_j2602(value, expected):
 def test_linversion_j2602_default(value):
     result = parse_lin_version(value)
     assert not result.use_j2602
-
+@pytest.mark.unit()
 @pytest.mark.parametrize(
     ('value'),
     [

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -223,3 +223,4 @@ def test_parse_linversion(value, expected):
 def test_linversion_j2602_compare(a, b, op, result):
     assert op(a, b) == result
 
+

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -222,5 +222,3 @@ def test_parse_linversion(value, expected):
 )
 def test_linversion_j2602_compare(a, b, op, result):
     assert op(a, b) == result
-
-

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -145,6 +145,7 @@ def test_linversion_iso_invalid(a, b, op, exc):
     with pytest.raises(exc):
         op(a, b)
 
+@pytest.mark.unit()
 @pytest.mark.parametrize(
     ('value'),
     [
@@ -206,6 +207,9 @@ def test_parse_linversion(value, expected):
         (J2602Version(1, 0, 1), LIN_VERSION_2_0, J2602Version.__eq__, True),
         (J2602Version(1, 0, 1), J2602Version(1, 1, 1), J2602Version.__eq__, False),
         (J2602Version(1, 0, 1), J2602Version(1, 0, 1), J2602Version.__eq__, True),
+        (J2602Version(2, 0, 1), J2602Version(1, 0, 1), J2602Version.__gt__, True),
+        (J2602Version(1, 0, 1), J2602Version(2, 0, 1), J2602Version.__lt__, True),
+        (J2602Version(1, 0, 1), "Other type", J2602Version.__eq__, False),
         (J2602Version(1, 0, 1), LIN_VERSION_2_2, J2602Version.__eq__, False),
         (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__eq__, False),
         (J2602Version(1, 0, 1), LIN_VERSION_2_2, J2602Version.__lt__, True),
@@ -214,6 +218,8 @@ def test_parse_linversion(value, expected):
         (J2602Version(1, 0, 1), LIN_VERSION_1_3, J2602Version.__lt__, False),
         (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__gt__, False),
         (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__ne__, True),
+        (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__ge__, False),
+        (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__le__, True),
         (J2602Version(1, 0, 1), LIN_VERSION_2_2, J2602Version.__ne__, True),
         (LIN_VERSION_2_0, J2602Version(1, 0, 1), LinVersion.__eq__, True),
         (LIN_VERSION_2_2, J2602Version(1, 0, 1), LinVersion.__gt__, True),
@@ -222,3 +228,18 @@ def test_parse_linversion(value, expected):
 )
 def test_linversion_j2602_compare(a, b, op, result):
     assert op(a, b) == result
+
+
+@pytest.mark.unit()
+@pytest.mark.parametrize(
+    ('func', 'arg'),
+    [
+        (J2602Version(2, 0, 1).__gt__, "J2602_3_0.1"),
+        (J2602Version(2, 0, 1).__lt__, "J2602_3_0.1"),
+        (J2602Version(2, 0, 1).__ge__, "J2602_3_0.1"),
+        (J2602Version(2, 0, 1).__le__, "J2602_3_0.1")
+    ]
+)
+def test_linversion_j2602_typerror(func, arg):
+    with pytest.raises(TypeError):
+        func(arg)

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 import pytest
-from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, Iso17987Version, parse_lin_version, parse_j2602_version
+from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, LinVersion, Iso17987Version, parse_lin_version, J2602Version
 
 @pytest.mark.unit()
 @pytest.mark.parametrize(
@@ -150,7 +150,8 @@ def test_linversion_iso_invalid(a, b, op, exc):
     [
         '',
         '2.1.2',
-        'ISO17987:abc'
+        'ISO17987:abc',
+        'J2602_1_1_1.0',
     ]
 )
 def test_linversion_parse_invalid(value):
@@ -159,29 +160,20 @@ def test_linversion_parse_invalid(value):
 
 @pytest.mark.unit()
 @pytest.mark.parametrize(
-    ('value', 'expected'),
+    ('value', 'major', 'minor', 'part'),
     [
-        ('J2602_1_1.0', LIN_VERSION_2_0),
-        ('J2602_3_1.0', LIN_VERSION_2_0),
-        ('J2602_1_1.1', LIN_VERSION_2_0),
+        ('J2602_1_1.0', 1, 0, 1),
+        ('J2602_3_1.0', 1, 0, 3),
+        ('J2602_1_1.1', 1, 1, 1),
     ]
 )
-def test_linversion_from_j2602(value, expected):
-    result = parse_lin_version(value)
-    assert result.__class__ == expected.__class__
-    assert result == expected
-    assert result.use_j2602
-@pytest.mark.unit()
-@pytest.mark.parametrize(
-    'value',
-    [
-        '1.1',
-        '2.2',
-    ]
-)
-def test_linversion_j2602_default(value):
-    result = parse_lin_version(value)
-    assert not result.use_j2602
+def test_linversion_j2602_valid(value, major, minor, part):
+    version = J2602Version.from_string(value)
+    assert version.major == major
+    assert version.minor == minor
+    assert version.part == part
+    assert str(J2602Version(major=major, minor=minor, part=part)) == value
+
 @pytest.mark.unit()
 @pytest.mark.parametrize(
     ('value'),
@@ -194,4 +186,40 @@ def test_linversion_j2602_default(value):
 )
 def test_linversion_unsupported_j2602(value):
     with pytest.raises(ValueError):
-        parse_j2602_version(value)
+        J2602Version.from_string(value)
+
+@pytest.mark.unit()
+@pytest.mark.parametrize(
+    ('value', 'expected'), [
+        ('2.0', LIN_VERSION_2_0),
+        ('ISO17987:2015', Iso17987Version(2015)),
+        ('J2602_3_1.0', J2602Version(1, 0, 3))
+    ]
+)
+def test_parse_linversion(value, expected):
+    version = parse_lin_version(value)
+    assert version == expected
+
+@pytest.mark.unit()
+@pytest.mark.parametrize(
+    'a, b, op, result', [
+        (J2602Version(1, 0, 1), LIN_VERSION_2_0, J2602Version.__eq__, True),
+        (J2602Version(1, 0, 1), J2602Version(1, 1, 1), J2602Version.__eq__, False),
+        (J2602Version(1, 0, 1), J2602Version(1, 0, 1), J2602Version.__eq__, True),
+        (J2602Version(1, 0, 1), LIN_VERSION_2_2, J2602Version.__eq__, False),
+        (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__eq__, False),
+        (J2602Version(1, 0, 1), LIN_VERSION_2_2, J2602Version.__lt__, True),
+        (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__lt__, True),
+        (J2602Version(1, 0, 1), LIN_VERSION_1_3, J2602Version.__gt__, True),
+        (J2602Version(1, 0, 1), LIN_VERSION_1_3, J2602Version.__lt__, False),
+        (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__gt__, False),
+        (J2602Version(1, 0, 1), Iso17987Version(2015), J2602Version.__ne__, True),
+        (J2602Version(1, 0, 1), LIN_VERSION_2_2, J2602Version.__ne__, True),
+        (LIN_VERSION_2_0, J2602Version(1, 0, 1), LinVersion.__eq__, True),
+        (LIN_VERSION_2_2, J2602Version(1, 0, 1), LinVersion.__gt__, True),
+        (LIN_VERSION_1_3, J2602Version(1, 0, 1), LinVersion.__lt__, True),
+    ]
+)
+def test_linversion_j2602_compare(a, b, op, result):
+    assert op(a, b) == result
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -223,6 +223,7 @@ def test_load_j2602_attributes():
     assert ldf.master.response_tolerance == 0.3
     assert list(ldf.slaves)[0].response_tolerance == 0.38
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     'file, max_header_length, master_response_tolerance, slave_response_tolerance',
     [

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,7 +6,7 @@ from ldfparser.parser import parse_ldf
 from ldfparser.frame import LinFrame
 from ldfparser.signal import LinSignal
 from ldfparser.encoding import ASCIIValue, BCDValue, LogicalValue
-from ldfparser.lin import Iso17987Version
+from ldfparser.lin import Iso17987Version, LIN_VERSION_2_0
 
 @pytest.mark.unit
 def test_load_valid_lin13():
@@ -211,3 +211,33 @@ def test_load_iso17987():
 
     assert isinstance(ldf.get_language_version(), Iso17987Version)
     assert ldf.get_language_version().revision == 2015
+
+@pytest.mark.unit
+def test_load_j2602_attributes():
+    path = os.path.join(os.path.dirname(__file__), "ldf", "j2602_1.ldf")
+    ldf = parse_ldf(path)
+
+    assert ldf.get_protocol_version() == LIN_VERSION_2_0
+    assert ldf.get_language_version() == LIN_VERSION_2_0
+    assert ldf.master.max_header_length == 24
+    assert ldf.master.response_tolerance == 0.3
+    assert list(ldf.slaves)[0].response_tolerance == 0.38
+
+@pytest.mark.parametrize(
+    'file, max_header_length, master_response_tolerance, slave_response_tolerance',
+    [
+        ("lin20.ldf", None, None, None),
+        ("j2602_1_no_values.ldf", 48, 0.4, 0.4)
+    ]
+)
+def test_j2602_attributes_default(
+        file, max_header_length, master_response_tolerance, slave_response_tolerance):
+    """
+    Should not set default value for J2602 attributes if protocol is not J2602
+    """
+    path = os.path.join(os.path.dirname(__file__), "ldf", file)
+    ldf = parse_ldf(path)
+
+    assert ldf.master.max_header_length == max_header_length
+    assert ldf.master.response_tolerance == master_response_tolerance
+    assert list(ldf.slaves)[0].response_tolerance == slave_response_tolerance


### PR DESCRIPTION
## Brief

- Allow parsing of files with protocol version J2602_1_1.0, which is for J2602:2012 and earlier SAE J2602 protocols. 
- Add new attributes to the master frame and node attributes: `max_header_length` and `response_tolerance`

Note support for J2602_1_2.0(SAE J2602:2021) is not added due to the following reasons:
1.  J2602_1_2.0 renames the term “master” to “commander” and the term “slave” with “responder”, which may require bigger changes.
2. The project I'm working on uses the legacy version, and I don't have example LDF files for the new version.

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [x] Create relevant test scenarios
  - [ ] Update examples
  - [x] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [x] Update version number

## Resolves

<!--
     Use the syntax: "Fixes #42" or "Resolves #42" to automatically link to issues.
 -->

+  (https://github.com/c4deszes/ldfparser/issues/118)

## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ Added new attribute `response_tolenrace` to `LinSlave` class, and default to `None` if loaded from files that are not based on `SAE J2602` protocols.
+ Added new attributes `max_header_length` and `response_tolenrace` to `LinMaster` class, and default to `None` if loaded from files that are not based on `SAE J2602` protocols.

+ snapshot tests are failing due to the addition of attributes and new LDF files.
