### PR TITLE
Support both upper and lower case E in scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2024-02-22
+
+### Changed
+
+- scientific/engineeering notation values can now have upper case E
+
 ## [0.23.0] - 2024-02-05
 
 ### Changed

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -122,7 +122,7 @@ signal_representations: "Signal_representation" "{" (signal_representation_node+
 signal_representation_node: ldf_identifier ":" ldf_identifier ("," ldf_identifier)* ";"
 
 C_INT: ("0x"HEXDIGIT+) | ("-"? INT) 
-C_FLOAT: ("-"? INT ("." INT)?) ("e" ("+" | "-")? INT)?
+C_FLOAT: ("-"? INT ("." INT)?) ("e" | "E" ("+" | "-")? INT)?
 LIN_VERSION: INT "." INT
 ISO_VERSION: "ISO17987" ":" INT
 J2602_VERSION: "J2602" "_" INT "_" INT "." INT

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -122,7 +122,7 @@ signal_representations: "Signal_representation" "{" (signal_representation_node+
 signal_representation_node: ldf_identifier ":" ldf_identifier ("," ldf_identifier)* ";"
 
 C_INT: ("0x"HEXDIGIT+) | ("-"? INT) 
-C_FLOAT: ("-"? INT ("." INT)?) ("e" | "E" ("+" | "-")? INT)?
+C_FLOAT: ("-"? INT ("." INT)?) (("e" | "E")("+" | "-")? INT)?
 LIN_VERSION: INT "." INT
 ISO_VERSION: "ISO17987" ":" INT
 J2602_VERSION: "J2602" "_" INT "_" INT "." INT

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.23.0
+version = 0.24.0

--- a/tests/ldf/lin_encoders.ldf
+++ b/tests/ldf/lin_encoders.ldf
@@ -65,11 +65,6 @@ Signal_encoding_types {
     physical_value, 1, 63, 0.0625, 7.0, "Volt";
     physical_value, 64, 191, 0.0104, 11.0, "Volt";
     physical_value, 192, 253, 0.0625, 13.0, "Volt";
-    physical_value, 0, 5.678e-04, 0.0625, 4, "Volt";
-    physical_value, 0, 7.654E-02, 0.01, 9, "Volt";
-    physical_value, 0, 3.778e02, 0.05, 12, "Volt";
-    physical_value, 0, 1.222E09, 1, 0, "Volt";
-    physical_value, 0, 3.5E+02, 0.5, 5, "Volt";
     logical_value, 254, "over voltage";
     logical_value, 255, "invalid";
   }
@@ -99,6 +94,13 @@ Signal_encoding_types {
   }
   BCDEncoding {
     bcd_value;
+  }
+  ScientificEncoding {
+    physical_value, 0, 255, 5.6785558246e-04, 0, "Ohm";
+    physical_value, 0, 255, 7.654E-02, 0, "Ohm";
+    physical_value, 0, 1024, 3.778e02, 0, "Ohm";
+    physical_value, 0, 1024, 1.222E09, 0, "Ohm";
+    physical_value, 0, 65535, 3.5E+02, 5, "Ohm";
   }
 }
 

--- a/tests/ldf/lin_encoders.ldf
+++ b/tests/ldf/lin_encoders.ldf
@@ -65,6 +65,11 @@ Signal_encoding_types {
     physical_value, 1, 63, 0.0625, 7.0, "Volt";
     physical_value, 64, 191, 0.0104, 11.0, "Volt";
     physical_value, 192, 253, 0.0625, 13.0, "Volt";
+    physical_value, 0, 5.678e-04, 0.0625, 4, "Volt";
+    physical_value, 0, 7.654E-02, 0.01, 9, "Volt";
+    physical_value, 0, 3.778e02, 0.05, 12, "Volt";
+    physical_value, 0, 1.222E09, 1, 0, "Volt";
+    physical_value, 0, 3.5E+02, 0.5, 5, "Volt";
     logical_value, 254, "over voltage";
     logical_value, 255, "invalid";
   }


### PR DESCRIPTION
## Brief
add support for upper case E in scientific notation values.

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [ ] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [x] Update version number

## Resolves
Resolves #134 

## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ Analyze how the change might impact existing code
Tests added to pytest validate it's backward compatible. 

+ Provide evidence that the feature is tested and covered properly
I made this new change to the local venv in my system.
