### PR TITLE
Improving signal overlapping error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.25.0] - 2024-04-22
+## [0.25.0] - 2024-04-28
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2024-04-22
+
+### Changed
+
+- Signals overlapping error message now includes relevant information
+
 ## [0.24.0] - 2024-02-22
 
 ### Changed

--- a/ldfparser/frame.py
+++ b/ldfparser/frame.py
@@ -94,13 +94,13 @@ class LinUnconditionalFrame(LinFrame):
         padding_value = "p" if pad_with_zero else "P"
         for (offset, signal) in signals:
             if offset < frame_offset:
-                raise ValueError(f"{frame_name}: {signal.name} is overlapping {prev_signal.name}")
+                raise ValueError(f"{frame_name}: {signal.name} at bit {offset} is overlapping {prev_signal.name}")
             if offset != frame_offset:
                 padding = offset - frame_offset
                 pattern += f"{padding_value}{padding}"
                 frame_offset += padding
             if frame_offset + signal.width > frame_bits:
-                raise ValueError(f"{signal.name} with offset {offset} spans outside frame!")
+                raise ValueError(f"{frame_name}: {signal.name} at bit {offset} spans outside frame!")
             if signal.is_array():
                 pattern += "u8" * int(signal.width / 8)
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.24.0
+version = 0.25.0


### PR DESCRIPTION
## Brief

- The current error when signals overlap doesn't include much information on which signals overlap and in which frame
- The new version includes the frame name and the signals which overlap

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [ ] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [ ] Update changelog
- [ ] Update version number

## Resolves

<!--
     Use the syntax: "Fixes #42" or "Resolves #42" to automatically link to issues.
 -->

+ Resolves #136 

## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ Only tested manually and through regression
