### PR TITLE
Physical value encoder rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Physical values are now rounded to the nearest integer, rather than down
+
+### Migration guide for 0.26.0
+
+- Physical values might be rounded the wrong way depending on the user's intention. This type of
+rounding should generally work better in values ranging from `0-X`, for example `49.9` is no longer
+rounded down to `49`. If this is undesired the user can in most cases offset the input by `0.5` and
+it should work as previously as `-0.5` rounds to `0`, check
+[Python's round function](https://docs.python.org/3/library/functions.html#round) for more.
+
 ## [0.25.0] - 2024-04-28
 
 ### Changed

--- a/ldfparser/encoding.py
+++ b/ldfparser/encoding.py
@@ -54,7 +54,7 @@ class PhysicalValue(ValueConverter):
 
         raw = self.offset
         if self.scale != 0:
-            raw = int((num - self.offset) / self.scale)
+            raw = round((num - self.offset) / self.scale)
 
         if raw < self.phy_min or raw > self.phy_max:
             raise ValueError(f"value: {raw} out of range ({self.phy_min}, {self.phy_max})")


### PR DESCRIPTION
## Brief

- Previously the physical values used `int(x)` to round the values, which rounds down
- The new one should be more consistent across input ranges

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [x] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [ ] Update version number

## Resolves

(Issue filed externally)

## Evidence

+ This change might break user code where users have not fully made sure to limit the input and output ranges, for example a signal intended to be encoded into `0-254` range if the user input could be as high `254.8` then this could lead to an error of the signal overflowing into `255`. But at least the encoder will catch cases if that would go outside it's range
