### PR TITLE
Multiple frames can be associated with one signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Signals can now be associated with multiple frames, accessible under `signal.frames`
+
+### Migration guide for 0.26.0
+
+- Newly written should be using `signal.frames` to determine the owners of a signal, for
+  compatibility reasons `signal.frame` is still set, but only when a signal is associated with one
+  frame
+
 ## [0.25.0] - 2024-04-28
 
 ### Changed

--- a/ldfparser/parser.py
+++ b/ldfparser/parser.py
@@ -129,7 +129,11 @@ def _populate_ldf_frames(json: dict, ldf: LDF):
         ldf._unconditional_frames[frame['name']] = frame_obj
 
         for (_, signal) in signals.items():
-            signal.frame = frame_obj
+            if len(signal.frames) == 0:
+                signal.frame = frame_obj    # signal has only appeared in one frame
+            elif len(signal.frames) >= 1:
+                signal.frame = None         # signal is in multiple frames
+            signal.frames.append(frame_obj)
 
 def _populate_ldf_event_triggered_frames(json: dict, ldf: LDF):
     if "event_triggered_frames" not in json:

--- a/ldfparser/signal.py
+++ b/ldfparser/signal.py
@@ -31,7 +31,9 @@ class LinSignal:
         self.publisher: 'LinNode' = None
         self.subscribers: List['LinNode'] = []
         self.encoding_type: 'LinSignalEncodingType' = None
-        self.frame: 'LinUnconditionalFrame' = None
+        self.frame: 'LinUnconditionalFrame' = None      # for compatibility reasons this is set
+                                                        # when the signal is added to only one frame
+        self.frames: List['LinUnconditionalFrame'] = []
 
     def __eq__(self, o: object) -> bool:
         if isinstance(o, LinSignal):


### PR DESCRIPTION
## Brief

- According to the standard a signal can be in multiple frames as long as it's published by the same node
- With this change we allow this mapping, however at the moment it's not checked whether the publishers are the same

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [x] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [x] Update changelog
- [ ] Update version number

## Resolves

<!--
     Use the syntax: "Fixes #42" or "Resolves #42" to automatically link to issues.
 -->

#141 

## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ For compatibility reasons the existing `signal.frame` is kept but it's only set when one frame is associated with a signal
